### PR TITLE
chore(ai): sync global AI instructions from cs-template

### DIFF
--- a/ai/global/code-quality.instructions.md
+++ b/ai/global/code-quality.instructions.md
@@ -9,8 +9,8 @@
 
 ## Pre-Commit
 
-- Unit tests must be written and must pass before every commit.
-- Never commit code that causes existing tests to fail.
+- Unit tests must be written before every commit — every new behaviour or change must have corresponding tests.
+- See [git.instructions.md](git.instructions.md) for the mandatory build and test verification rules that apply before every commit.
 
 ## Dead Code
 

--- a/ai/global/dotnet.instructions.md
+++ b/ai/global/dotnet.instructions.md
@@ -61,8 +61,30 @@ For example, for an assembly `This.Test.Example`:
 - Integration tests → `This.Test.Example.Integration.Tests`
 - Benchmarks → `This.Test.Example.Benchmark.Tests`
 
+## Build Before Push (MANDATORY)
+
+Before committing changes to any .NET repository:
+
+1. Run `dotnet build` from the solution root and verify it succeeds with no errors.
+2. Run `dotnet test` if a test project exists and verify all tests pass.
+3. Do NOT commit or push if the build or tests fail — fix the issues first.
+
+Never push code that does not compile. If you cannot fix a build error, report it instead of pushing broken code.
+
 ## Test Dependencies
 
 - All test projects must reference the latest release version of `FunFair.Test.Common`.
 - All test projects must import the latest release version of the `FunFair.Test.Source.Generator` source generator package.
 - Test fixture classes must derive from `FunFair.Test.Common.TestBase`.
+
+## Source File Organisation
+
+- **One type per file**: every C# source file must contain exactly one type (class, record, struct, interface, or enum). Do not define multiple types in a single file.
+- The file name must match the type name exactly (e.g. `FooBar.cs` for `class FooBar`).
+
+## Debugger Diagnostics
+
+- All `struct` types must have a `[DebuggerDisplay("...")]` attribute that shows their key fields.
+- All value types (records declared with positional parameters or `record struct`) must have a `[DebuggerDisplay("...")]` attribute.
+- All configuration/options classes (typically bound from `appsettings.json`) must have a `[DebuggerDisplay("...")]` attribute showing their key properties.
+- The `DebuggerDisplay` format string should show the most useful identifying information — typically a name, identifier, or URL.

--- a/ai/global/dotnet.instructions.md
+++ b/ai/global/dotnet.instructions.md
@@ -4,6 +4,17 @@
 
 These rules apply to all .NET solutions derived from this template.
 
+## Build and Test Before Commit (MANDATORY)
+
+- Before every commit, run:
+  ```
+  dotnet build
+  dotnet test
+  ```
+- If `dotnet build` fails, **do not commit**. Fix all build errors first.
+- If `dotnet test` fails, **do not commit**. Fix all failing tests first.
+- If build or test errors cannot be resolved, stop and ask the user for guidance.
+
 ## Asynchronous Code
 
 - Prefer `ValueTask` and `ValueTask<T>` over `Task` and `Task<T>` wherever possible — they avoid heap allocations in the common synchronous-completion path.

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -91,3 +91,25 @@ fi
   - Names the vulnerable package and the severity.
   - Describes the steps to fix it manually.
   - Is labelled `Security` and `AI-Work`.
+
+## Template Rule Escalation (Non-Template Repos Only)
+
+This section applies **only when working in a non-template repository** (i.e., any repo other than `credfeto/cs-template`).
+
+If, during work in a non-template repo, a gap or needed change is identified in the global template rules or instructions:
+
+1. **Do not** apply the rule change locally — template rules are managed centrally in `credfeto/cs-template`.
+2. Create a new issue in `credfeto/cs-template` using the GitHub CLI:
+   ```bash
+   gh issue create --repo credfeto/cs-template \
+     --title "<short description of the rule change>" \
+     --label "AI-Work" \
+     --body "..."
+   ```
+3. The issue body **must** include all of the following:
+   - **Source repository**: The repo where the need was discovered.
+   - **Current behaviour / gap**: What is missing or inconsistent in the existing rules.
+   - **Proposed rule text**: The concrete rule update or new instruction text being requested.
+   - **Reason for template propagation**: Why this change should apply across all repos, not just locally.
+4. After creating the issue, note its URL in any relevant commit or PR description so the context is not lost.
+5. Continue work in the current repo without waiting for the template issue to be resolved.

--- a/ai/global/git.instructions.md
+++ b/ai/global/git.instructions.md
@@ -2,6 +2,17 @@
 
 [Back to Global Instructions Index](index.md)
 
+## Language/Runtime Prerequisites (MANDATORY before any work)
+
+- Before starting any work, verify that all languages and runtimes required by the project are installed and available.
+- If a required language or runtime is not installed, **stop immediately**. Do not attempt to work around the missing tooling, scaffold code, or make partial changes. Ask the user to install it first.
+
+## Build and Test Verification (MANDATORY before any commit or push)
+
+- Before committing or pushing any change, the project must build and all tests must pass.
+- If the build fails or any test fails, **do not commit or push**. Fix the issues first.
+- If build or test errors cannot be resolved, stop and ask the user for guidance.
+
 ## Git Identity Check (MANDATORY before any commit)
 
 Before making any git commit, verify the configured identity is correct and GPG signing is enabled:
@@ -32,13 +43,13 @@ fi
 - Before starting work, either:
   - Find an existing issue that is a **100% match** for the task — confirm with the user before linking to it, or
   - Create a new issue that includes the original prompt and a clear description of what needs to be done.
-- If the task is significantly complex, break it into sub-issues and work on each one individually — close each sub-issue as soon as the relevant commit has been pushed to the working branch.
+- For complex or multi-component tasks, see [task-workflow.instructions.md](task-workflow.instructions.md) for how to break work into sub-issues and track progress.
 - Issue numbers must be referenced in commit messages and branch names where applicable (see branch naming rules above).
 - If work on an issue is abandoned for any reason (e.g. benchmarks show no gain, investigation reveals the change is not worthwhile), comment on the issue with the findings before closing or leaving it — do not abandon an issue silently.
 
 ## Branching
 
-- All new work must be done in a branch. Never commit directly to `main`.
+- All new work must be done in a branch. Never commit directly to `main` (also enforced by the Pre-Commit Branch Check above).
 - Before making any changes, ensure the current branch is `main` and is up-to-date with `origin`.
 - Until there is an explicit change in task, continue working in the same branch.
 - Before starting any new piece of work on an existing branch, check whether `origin/main` has been updated — if it has, rebase the branch onto `origin/main` before continuing, resolving any conflicts in a way that retains the intent of the current branch's work.

--- a/ai/global/index.md
+++ b/ai/global/index.md
@@ -13,7 +13,7 @@ This is an index of global instructions that apply to all projects.
 
 | File | Description |
 |------|-------------|
-| [git.instructions.md](git.instructions.md) | GitHub issue management, branching strategy, branch naming, commit size, commit message format (Conventional Commits, prompt in body) |
+| [git.instructions.md](git.instructions.md) | Language/runtime prerequisites, build and test verification before commit/push, GitHub issue management, branching strategy, branch naming, commit size, commit message format (Conventional Commits, prompt in body) |
 | [documentation.instructions.md](documentation.instructions.md) | README, CHANGELOG (KeepAChangeLog, `Credfeto.Changelog.Cmd`), and docs folder conventions |
 | [code-quality.instructions.md](code-quality.instructions.md) | 100% code coverage, pre-commit test requirements, dead code removal, immutability, parameterised tests, test quality, refactoring, compile-time configuration testing |
 | [packages.instructions.md](packages.instructions.md) | Secure package versions, managed vs native libraries, avoiding deprecated or obsolete packages |
@@ -25,5 +25,6 @@ This is an index of global instructions that apply to all projects.
 | [security.instructions.md](security.instructions.md) | No secrets in code, input validation, output sanitisation, threat modelling, vulnerability scanning |
 | [error-handling.instructions.md](error-handling.instructions.md) | Explicit error handling, no swallowed exceptions, propagation and safe surfacing of errors |
 | [logging.instructions.md](logging.instructions.md) | Structured logging, log levels, what to log and what not to log (no PII, no secrets) |
-| [dotnet.instructions.md](dotnet.instructions.md) | .NET-specific: solution structure, test assembly naming, FunFair.Test.Common, FunFair.BuildCheck |
+| [dotnet.instructions.md](dotnet.instructions.md) | .NET-specific: build and test before commit (`dotnet build`/`dotnet test`), solution structure, test assembly naming, FunFair.Test.Common, FunFair.BuildCheck |
+| [task-workflow.instructions.md](task-workflow.instructions.md) | Issue/PR assignment, splitting large tasks into sub-issues worked one at a time, file status tracking, commit/push cadence, multi-agent routing (Code Writer → Code Tester → Code Reviewer → Changelog → Committer), resuming interrupted work |
  

--- a/ai/global/logging.instructions.md
+++ b/ai/global/logging.instructions.md
@@ -10,7 +10,9 @@
   - The logging class must be named after the class it serves, suffixed with `LoggingExtensions` — e.g. for a class `Foo`, the logging class is `FooLoggingExtensions`.
   - The logging class must be `internal` and `static`.
 
-## Structured Logging- All logging must use structured logging — log data as key-value pairs or structured objects, not concatenated strings.
+## Structured Logging
+
+- All logging must use structured logging — log data as key-value pairs or structured objects, not concatenated strings.
 - This ensures logs are machine-readable and queryable in log aggregation tools.
 
 ## Log Levels

--- a/ai/global/task-workflow.instructions.md
+++ b/ai/global/task-workflow.instructions.md
@@ -1,0 +1,165 @@
+# Task Workflow Instructions
+
+[Back to Global Instructions Index](index.md)
+
+## Issue Assignment
+
+- **When picking up an issue to work on**, assign it to yourself (`gh issue edit <number> --add-assignee @me`) before starting any work.
+- **Do not pick up issues already assigned to someone else.** If an issue is assigned, skip it and move to the next available one.
+- Only work on issues that are unassigned, or already assigned to you.
+
+## PR Assignment
+
+- **When creating or updating a PR**, always add yourself as an assignee (`gh pr edit <number> --add-assignee @me`).
+- Do this at the time of PR creation, or immediately after if the PR already exists.
+
+## Large Multi-Handler / Multi-App Tasks
+
+When given a task that spans multiple handlers, apps, or components (e.g. "ensure 100% coverage for all handlers", "migrate all projects to a new package"):
+
+1. **Create a top-level GitHub issue** if none is specified. Assign it to whoever asked. Include the full original prompt as the issue body.
+2. **Comment findings** on the issue before starting any work (e.g. list handlers found, current state of each).
+3. **For each handler/app/component**, create a sub-issue referencing the top-level issue. Use the sub-issue number in the branch name and commit messages.
+4. **Work on one handler/component at a time** — do not start the next until the current one is committed and pushed.
+5. **Push each branch** when the handler's work is complete.
+6. **Close the sub-issue** as soon as the relevant commits have been pushed to the working branch — do not leave sub-issues open after the work is done.
+
+## Sub-issue File Status Tracking
+
+Each sub-issue (not the top-level issue) should contain the list of files being worked on and their status. Keep this updated as work progresses:
+
+- Use a table or checklist with one row per file.
+- Mark each file as: `❌ Not started`, `🔄 In progress`, or `✅ Done`.
+- Update the sub-issue **immediately after each commit+push** that completes a file.
+- For complex files where multiple rounds of changes are needed, update the sub-issue after each commit+push.
+
+The top-level issue should only track handler/app-level status (which sub-issues are open/closed, which branches are merged).
+
+## GitHub Issue Updates
+
+- **Only update issues if the GitHub CLI (`gh`) is installed and properly authenticated.** To check: run `gh auth status`. If it fails or shows unauthenticated, determine current state by reading the code and git log instead — do not attempt issue updates.
+- **Update the sub-issue** after each significant piece of work (each commit+push to the branch).
+- **Update the top-level issue** when the overall status changes (e.g. a sub-issue is closed, a PR is raised).
+- When resuming work, update the issue with current state before continuing.
+
+## Commit, Push, and Issue Update Cadence
+
+For coverage tasks, the cadence per file is:
+
+1. Write tests until the file reaches target coverage.
+2. `git commit` the test file (one file per commit).
+3. `git push` the branch immediately — do not batch pushes.
+4. Update the sub-issue to mark that file as done.
+5. Move to the next file.
+
+For complex files where it takes multiple rounds of changes:
+
+1. After each round: commit, push, update the sub-issue.
+2. Do not wait until the file is fully complete before the first push.
+
+> **Note:** Commits may take longer than expected due to pre-commit hooks running linters. Do not assume failure if the commit is slow — wait for the hooks to complete before retrying.
+
+## Multi-Agent Implementation and Review Pattern
+
+### Agent Roles
+
+**Orchestrator**
+
+- Checks for `CHANGES_REQUESTED` PRs first — these always take priority over new issues.
+- Determines work type and routes to the correct agent.
+- Never does implementation itself.
+
+**Code Writer**
+
+- Implements a GitHub issue: reads all instruction files, writes production code and the corresponding tests.
+- Does NOT commit, push, or update the changelog — hands off to Code Tester once implementation is complete.
+
+**Code Tester**
+
+- Runs after Code Writer (or Code Fixer) has finished writing code and tests.
+- Runs the project build.
+- Runs all tests.
+- Checks test coverage against all code added or changed in the current branch (`git diff origin/main...HEAD` to identify changed files).
+- **If the build fails**: reports the full error output to Code Writer and waits for a fix — does not proceed.
+- **If any test fails**: reports the test name, failure message, and full output to Code Writer and waits for a fix — does not proceed.
+- **If new or changed code is not fully covered by tests**: reports the exact file paths and line ranges that lack coverage to Code Writer and waits for additional tests — does not proceed.
+- Loops with Code Writer until all three conditions are satisfied: build passes, all tests pass, all new/changed code is covered.
+- Does not modify code or tests itself — reports and verifies only.
+
+**Code Reviewer**
+
+- Reviews a branch against every rule in the instruction files.
+- Runs `git diff origin/main...HEAD`, checks every changed file.
+- Launches three sub-agents **in parallel** against the full diff:
+  1. **Reuse agent** — searches codebase for existing utilities/helpers that duplicate newly written code.
+  2. **Quality agent** — checks for redundant state, copy-paste variation, leaky abstractions, unnecessary comments.
+  3. **Efficiency agent** — checks for unnecessary work, missed concurrency, hot-path bloat, repeated lookups.
+- Aggregates findings, fixes each real issue in its own commit, skips false positives.
+- After applying any fixes, Code Tester must re-run and pass before this round is considered complete.
+- Reports `{"clean": true}` or `{"clean": false, "fixes": [...]}`.
+- Loops with Code Writer (via Code Tester) until clean, capped at 5 iterations.
+
+**Code Fixer (PR Review Responder)**
+
+- Addresses `CHANGES_REQUESTED` review comments on an existing PR.
+- Each review comment gets its own separate commit.
+- Hands off to Code Tester after each fix rather than running build/tests itself.
+
+**Rebase Agent**
+
+- Rebases a named branch onto `origin/main`.
+- Resolves CHANGELOG conflicts by keeping entries from both sides (never discarding either).
+- Force-pushes with `--force-with-lease`.
+
+**CI Debugger**
+
+- Invoked when CI fails and the cause is not obvious from the code change.
+- Reads full workflow logs (`gh run view --log-failed`), identifies root cause.
+- Fixes the cause if it is code-related; if environmental or infrastructure, escalates with a clear description.
+
+**Changelog**
+
+- Runs after both Code Tester and Code Reviewer are satisfied — never before.
+- Reads `git diff origin/main...HEAD` to understand what changed.
+- Adds appropriate changelog entries using the `dotnet changelog` tool (see [documentation.instructions.md](documentation.instructions.md) for the exact command syntax) — never edits `CHANGELOG.md` manually.
+- Does NOT commit — that is Committer's responsibility.
+- Does NOT run build or tests — that is Code Tester's responsibility.
+
+**Committer**
+
+- Runs after the Changelog agent has written the changelog entry.
+- Verifies git identity and GPG signing are correctly configured (runs the checks from [git.instructions.md](git.instructions.md#git-identity-check-mandatory-before-any-commit)).
+- If either check fails: stops and reports the misconfiguration — does not proceed.
+- Commits all pending code and test changes as one commit (Conventional Commits format, original prompt in body prefixed with `Prompt:`, GPG signed).
+- Commits `CHANGELOG.md` changes as a separate subsequent commit (also GPG signed).
+- Pushes all commits to `origin` immediately after.
+- Does not open the PR — that is handled downstream.
+
+**Dependency Updater**
+
+- Reviews Dependabot PRs: checks if the update is a safe patch/minor bump with no security advisories and CI passing.
+- Auto-merges safe updates; flags breaking changes or major version bumps to the user.
+- Never merges a dependency update that has CI failures or is a major version bump without user confirmation.
+
+### Routing Rules
+
+| Work type | Agent sequence                                                                                                                                                                       |
+|---|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| New feature / bug fix / refactor | Code Writer → Code Tester (loop ≤5 with Code Writer) → Code Reviewer (loop ≤5, re-running Code Write and Code Tester each round) → Changelog → Committer → CI Monitor → PR Submitter |
+| `CHANGES_REQUESTED` on existing PR | Code Fixer → Code Tester (loop ≤5 with Code Fixer) → Code Reviewer (loop ≤5, re-running Code Write and Code Tester each round) → Changelog → Committer → CI Monitor → PR Submitter                  |
+| Coverage-only task | Code Writer (tests only) → Code Tester (loop ≤5 with Code Writer) → Code Reviewer (loop ≤5, re-running Code Write and Code Tester each round) → Changelog → Committer → CI Monitor → PR Submitter   |
+| Documentation-only | Code Writer (docs only) → PR Submitter                                                                                                                                               |
+| Rebase requested | Rebase Agent → PR Submitter                                                                                                                                                          |
+| CI failure (unknown cause) | CI Debugger                                                                                                                                                                          |
+| Dependabot / dependency update | Dependency Updater                                                                                                                                                                   |
+
+## Resuming Interrupted Work
+
+When asked to resume a large task:
+
+- Check the status of existing issues and branches (open, closed, merged).
+- If a branch has been merged into main, skip that— the work is done.
+- If a branch exists but is unmerged, decide whether to continue it or delete and recreate based on its state.
+- Determine current position from issue/branch status and continue from there.
+- Update the top-level issue with the current status and next steps before resuming work.
+- Update the sub-issue as work progresses.


### PR DESCRIPTION
## Summary

- Sync `ai/global/` from [credfeto/cs-template](https://github.com/credfeto/cs-template) main
- Add new `task-workflow.instructions.md` — covers issue/PR assignment, splitting large tasks into sub-issues worked one at a time, file status tracking, commit/push cadence, multi-agent routing, and resuming interrupted work
- Update `git.instructions.md` with Language/Runtime Prerequisites, Build and Test Verification, and Dependabot vulnerability warning sections
- Update `dotnet.instructions.md`, `code-quality.instructions.md`, `logging.instructions.md`, `index.md` to latest

## Test plan
- [ ] Verify all 15 `ai/global/` files are present and match cs-template main

🤖 Generated with [Claude Code](https://claude.com/claude-code)