### PR TITLE
feat: post startup and GitHub auth status messages to Discord on launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - One-type-per-file convention for all C# source files
 - `LabelFilter` and `NoWorkFilter` as arrays in configuration
 - `AllowedOwners` and `ExcludedRepos` filter options for repo-level filtering
+- post startup and GitHub auth status messages to Discord on launch
 ### Fixed
 - Removed unused `Mediator` runtime package reference from `Credfeto.Dispatcher.Server` — `Mediator.SourceGenerator` source generator is sufficient; no separate runtime package is needed for a simple background service
 ### Changed

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/LoggingExtensions/StartupNotificationServiceLoggingExtensions.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/LoggingExtensions/StartupNotificationServiceLoggingExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Credfeto.Dispatcher.GitHub.BackgroundServices.LoggingExtensions;
+
+internal static partial class StartupNotificationServiceLoggingExtensions
+{
+    [LoggerMessage(EventId = 10, Level = LogLevel.Information, Message = "Startup notification service starting")]
+    public static partial void LogStartupNotificationServiceStarting(this ILogger logger);
+
+    [LoggerMessage(EventId = 11, Level = LogLevel.Information, Message = "GitHub authentication successful")]
+    public static partial void LogGitHubAuthenticationSuccessful(this ILogger logger);
+
+    [LoggerMessage(EventId = 12, Level = LogLevel.Error, Message = "GitHub authentication failed with status code {StatusCode}")]
+    public static partial void LogGitHubAuthenticationFailed(this ILogger logger, int statusCode);
+
+    [LoggerMessage(EventId = 13, Level = LogLevel.Error, Message = "Error sending startup notification to Discord")]
+    public static partial void LogStartupNotificationError(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 14, Level = LogLevel.Error, Message = "Error checking GitHub authentication status")]
+    public static partial void LogGitHubAuthCheckError(this ILogger logger, Exception exception);
+}

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/StartupNotificationService.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/StartupNotificationService.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.Date.Interfaces;
+using Credfeto.Dispatcher.Discord.DataTypes;
+using Credfeto.Dispatcher.Discord.Interfaces;
+using Credfeto.Dispatcher.GitHub.BackgroundServices.LoggingExtensions;
+using Credfeto.Dispatcher.GitHub.Interfaces;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Credfeto.Dispatcher.GitHub.BackgroundServices;
+
+public sealed class StartupNotificationService : BackgroundService
+{
+    private static readonly Uri GitHubNotificationsUri = new("https://github.com/notifications");
+    private static readonly Uri GitHubTokenSettingsUri = new("https://github.com/settings/tokens");
+    private static readonly Uri RepositoryUri = new("https://github.com/credfeto/credfeto-dispatcher");
+
+    private readonly ICurrentTimeSource _currentTimeSource;
+    private readonly IDiscordDispatcher _discordDispatcher;
+    private readonly ILogger<StartupNotificationService> _logger;
+    private readonly IGitHubNotificationPoller _poller;
+
+    public StartupNotificationService(
+        IGitHubNotificationPoller poller,
+        IDiscordDispatcher discordDispatcher,
+        ICurrentTimeSource currentTimeSource,
+        ILogger<StartupNotificationService> logger
+    )
+    {
+        this._poller = poller;
+        this._discordDispatcher = discordDispatcher;
+        this._currentTimeSource = currentTimeSource;
+        this._logger = logger;
+    }
+
+    public override async Task StartAsync(CancellationToken cancellationToken)
+    {
+        this._logger.LogStartupNotificationServiceStarting();
+
+        try
+        {
+            DiscordMessage message = BuildAppStartedMessage(this._currentTimeSource.UtcNow());
+
+            await this._discordDispatcher.SendAsync(message: message, cancellationToken: cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            this._logger.LogStartupNotificationError(exception: exception);
+        }
+
+        await base.StartAsync(cancellationToken);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await this.CheckGitHubAuthAsync(stoppingToken);
+    }
+
+    private static DiscordMessage BuildAppStartedMessage(in DateTimeOffset timestamp)
+    {
+        string machineName = Environment.MachineName;
+        Assembly assembly = typeof(StartupNotificationService).Assembly;
+        string product = assembly.GetCustomAttribute<AssemblyProductAttribute>()?.Product ?? "Credfeto Dispatcher";
+        string version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                         ?? assembly.GetName().Version?.ToString()
+                         ?? "unknown";
+
+        DiscordEmbed embed = new(
+            Title: "Application started",
+            Description: $"Version: {version}\nHost: {machineName}\nStarted at: {timestamp:yyyy-MM-dd HH:mm:ss} UTC",
+            Url: RepositoryUri,
+            Color: 0x57F287
+        );
+
+        return new DiscordMessage(Content: $"**{product}** is starting up", Embeds: [embed]);
+    }
+
+    private async ValueTask CheckGitHubAuthAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await this._poller.PollAsync(cancellationToken);
+
+            this._logger.LogGitHubAuthenticationSuccessful();
+
+            await this.TrySendAuthSuccessMessageAsync(cancellationToken);
+        }
+        catch (HttpRequestException httpException) when (httpException.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+        {
+            int statusCode = (int)(httpException.StatusCode ?? HttpStatusCode.Unauthorized);
+
+            this._logger.LogGitHubAuthenticationFailed(statusCode: statusCode);
+
+            await this.TrySendAuthFailureMessageAsync(statusCode: statusCode, cancellationToken: cancellationToken);
+        }
+        catch (OperationCanceledException exception)
+        {
+            this._logger.LogStartupNotificationError(exception: exception);
+        }
+        catch (Exception exception)
+        {
+            this._logger.LogGitHubAuthCheckError(exception: exception);
+        }
+    }
+
+    private async ValueTask TrySendAuthSuccessMessageAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            DiscordEmbed embed = new(
+                Title: "GitHub authentication successful",
+                Description: "The GitHub token is valid and the notifications endpoint responded successfully.",
+                Url: GitHubNotificationsUri,
+                Color: 0x57F287
+            );
+
+            DiscordMessage message = new(Content: "\u2705 GitHub auth check passed", Embeds: [embed]);
+
+            await this._discordDispatcher.SendAsync(message: message, cancellationToken: cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            this._logger.LogStartupNotificationError(exception: exception);
+        }
+    }
+
+    private async ValueTask TrySendAuthFailureMessageAsync(int statusCode, CancellationToken cancellationToken)
+    {
+        try
+        {
+            DiscordEmbed embed = new(
+                Title: "GitHub authentication failed",
+                Description: $"HTTP {statusCode} received from the GitHub notifications endpoint. Check that the token is valid and has the `notifications` scope.",
+                Url: GitHubTokenSettingsUri,
+                Color: 0xED4245
+            );
+
+            DiscordMessage message = new(Content: "\u274c GitHub auth check failed", Embeds: [embed]);
+
+            await this._discordDispatcher.SendAsync(message: message, cancellationToken: cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            this._logger.LogStartupNotificationError(exception: exception);
+        }
+    }
+}

--- a/src/Credfeto.Dispatcher.GitHub/Credfeto.Dispatcher.GitHub.csproj
+++ b/src/Credfeto.Dispatcher.GitHub/Credfeto.Dispatcher.GitHub.csproj
@@ -48,6 +48,8 @@
     <ProjectReference Include="..\Credfeto.Dispatcher.Shared\Credfeto.Dispatcher.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Credfeto.Date" Version="1.1.150.1668" />
+    <PackageReference Include="Credfeto.Date.Interfaces" Version="1.1.150.1668" />
     <PackageReference Include="Credfeto.Services.Startup.Interfaces" Version="1.1.143.1554" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.6" />

--- a/src/Credfeto.Dispatcher.GitHub/GitHubSetup.cs
+++ b/src/Credfeto.Dispatcher.GitHub/GitHubSetup.cs
@@ -13,6 +13,7 @@ public static class GitHubSetup
             .AddHttpClient<IGitHubNotificationPoller, GitHubNotificationPoller>()
             .Services
             .AddSingleton<INotificationFilter, NotificationFilter>()
+            .AddHostedService<StartupNotificationService>()
             .AddHostedService<GitHubPollingWorker>();
     }
 }


### PR DESCRIPTION
## Summary

- Adds `StartupNotificationService` (a `BackgroundService`) to `Credfeto.Dispatcher.GitHub` that posts two Discord messages on startup via the existing `IDiscordDispatcher`
- Message 1 (app-started): posted in `StartAsync` with product name, version, hostname, and UTC timestamp — failures are caught and logged so they don't block the main polling loop
- Message 2 (GitHub auth check): posted after the first `IGitHubNotificationPoller.PollAsync()` call completes — success (200/304) or failure (401/403) is detected and a corresponding Discord embed is sent
- Uses `ICurrentTimeSource` from `Credfeto.Date` for timestamps (avoids the `FFS0005` analyser rule)
- Uses `LoggerMessage` source generators (`StartupNotificationServiceLoggingExtensions`)
- Service registered in `GitHubSetup.AddGitHub()` ahead of `GitHubPollingWorker`

## Acceptance Criteria

- [x] Discord message posted on startup with app version and hostname
- [x] Discord message posted after first GitHub API call with auth success/failure
- [x] Both messages sent via `IDiscordDispatcher`
- [x] Failures in the startup message do not prevent the main polling loop from starting
- [x] Build passes, all tests pass

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 3 test assemblies passed
- [x] `buildcheck` — no errors found

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)