### PR TITLE
chore: add Polly resilience pipeline to HttpClient registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - One-type-per-file convention for all C# source files
 - `LabelFilter` and `NoWorkFilter` as arrays in configuration
 - `AllowedOwners` and `ExcludedRepos` filter options for repo-level filtering
+- Polly standard resilience handler to GitHub and Discord HttpClient registrations via Microsoft.Extensions.Http.Resilience
 ### Fixed
 - Removed unused `Mediator` runtime package reference from `Credfeto.Dispatcher.Server` — `Mediator.SourceGenerator` source generator is sufficient; no separate runtime package is needed for a simple background service
 ### Changed

--- a/src/Credfeto.Dispatcher.Discord/Credfeto.Dispatcher.Discord.csproj
+++ b/src/Credfeto.Dispatcher.Discord/Credfeto.Dispatcher.Discord.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <PackageReference Include="Credfeto.Services.Startup.Interfaces" Version="1.1.143.1554" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
   </ItemGroup>

--- a/src/Credfeto.Dispatcher.Discord/DiscordSetup.cs
+++ b/src/Credfeto.Dispatcher.Discord/DiscordSetup.cs
@@ -10,6 +10,7 @@ public static class DiscordSetup
     {
         return services
             .AddHttpClient<IDiscordDispatcher, DiscordWebhookDispatcher>()
+            .AddStandardResilienceHandler()
             .Services;
     }
 }

--- a/src/Credfeto.Dispatcher.GitHub/Credfeto.Dispatcher.GitHub.csproj
+++ b/src/Credfeto.Dispatcher.GitHub/Credfeto.Dispatcher.GitHub.csproj
@@ -51,6 +51,7 @@
     <PackageReference Include="Credfeto.Services.Startup.Interfaces" Version="1.1.143.1554" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
   </ItemGroup>

--- a/src/Credfeto.Dispatcher.GitHub/GitHubSetup.cs
+++ b/src/Credfeto.Dispatcher.GitHub/GitHubSetup.cs
@@ -11,6 +11,7 @@ public static class GitHubSetup
     {
         return services
             .AddHttpClient<IGitHubNotificationPoller, GitHubNotificationPoller>()
+            .AddStandardResilienceHandler()
             .Services
             .AddSingleton<INotificationFilter, NotificationFilter>()
             .AddHostedService<GitHubPollingWorker>();


### PR DESCRIPTION
## Summary

Closes #9

- Adds `Microsoft.Extensions.Http.Resilience` (v10.5.0) package to `Credfeto.Dispatcher.GitHub` and `Credfeto.Dispatcher.Discord` projects
- Chains `.AddStandardResilienceHandler()` on both `AddHttpClient<T>()` registrations in `GitHubSetup.cs` and `DiscordSetup.cs`
- Provides retry with exponential backoff, circuit breaker, and per-request timeout via the standard pipeline

## Test plan

- [x] `GitHubSetup.cs` named client has a resilience pipeline via `AddStandardResilienceHandler()`
- [x] `DiscordSetup.cs` named client has a resilience pipeline via `AddStandardResilienceHandler()`
- [x] Build passes (`dotnet build` — 0 warnings, 0 errors)
- [x] All tests pass (`dotnet test`)
- [x] BuildCheck passes (`buildcheck -Solution src/Credfeto.Dispatcher.slnx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)