### PR TITLE
feat: post startup and GitHub auth status messages to Discord on launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Standard resilience handler (retry with exponential backoff, circuit breaker, timeout) via Microsoft.Extensions.Http.Resilience on both GitHub and Discord HTTP clients
 - Documentation instructions for keeping README.md configuration section up-to-date when configuration options change
 - Structured `ILogger<T>` logging throughout the polling and dispatch pipeline: worker startup/shutdown, poll cycles (ETag sent, 304 Not Modified or notification count), per-notification debug entries, filter pass/drop decisions, dispatch to Discord, and Discord webhook non-success warnings
+- Post startup and GitHub auth status messages to Discord on launch
 ### Fixed
 - Removed unused `Mediator` runtime package reference from `Credfeto.Dispatcher.Server` — `Mediator.SourceGenerator` source generator is sufficient; no separate runtime package is needed for a simple background service
 - Updated gitleaks configuration to suppress false positive secret detection caused by logging extension class name matching the GitHub token regex pattern

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/LoggingExtensions/StartupNotificationServiceLoggingExtensions.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/LoggingExtensions/StartupNotificationServiceLoggingExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Credfeto.Dispatcher.GitHub.BackgroundServices.LoggingExtensions;
+
+internal static partial class StartupNotificationServiceLoggingExtensions
+{
+    [LoggerMessage(EventId = 10, Level = LogLevel.Information, Message = "Startup notification service starting")]
+    public static partial void LogStartupNotificationServiceStarting(this ILogger logger);
+
+    [LoggerMessage(EventId = 11, Level = LogLevel.Information, Message = "GitHub authentication successful")]
+    public static partial void LogGitHubAuthenticationSuccessful(this ILogger logger);
+
+    [LoggerMessage(EventId = 12, Level = LogLevel.Error, Message = "GitHub authentication failed with status code {StatusCode}")]
+    public static partial void LogGitHubAuthenticationFailed(this ILogger logger, int statusCode);
+
+    [LoggerMessage(EventId = 13, Level = LogLevel.Error, Message = "Error sending startup notification to Discord")]
+    public static partial void LogStartupNotificationError(this ILogger logger, Exception exception);
+
+    [LoggerMessage(EventId = 14, Level = LogLevel.Error, Message = "Error checking GitHub authentication status")]
+    public static partial void LogGitHubAuthCheckError(this ILogger logger, Exception exception);
+}

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/StartupNotificationService.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/StartupNotificationService.cs
@@ -23,10 +23,10 @@ public sealed class StartupNotificationService : BackgroundService
     private readonly ICurrentTimeSource _currentTimeSource;
     private readonly IDiscordDispatcher _discordDispatcher;
     private readonly ILogger<StartupNotificationService> _logger;
-    private readonly IGitHubNotificationPoller _poller;
+    private readonly INotificationPoller _poller;
 
     public StartupNotificationService(
-        IGitHubNotificationPoller poller,
+        INotificationPoller poller,
         IDiscordDispatcher discordDispatcher,
         ICurrentTimeSource currentTimeSource,
         ILogger<StartupNotificationService> logger

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/StartupNotificationService.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/StartupNotificationService.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.Date.Interfaces;
+using Credfeto.Dispatcher.Discord.DataTypes;
+using Credfeto.Dispatcher.Discord.Interfaces;
+using Credfeto.Dispatcher.GitHub.BackgroundServices.LoggingExtensions;
+using Credfeto.Dispatcher.GitHub.Interfaces;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Credfeto.Dispatcher.GitHub.BackgroundServices;
+
+public sealed class StartupNotificationService : BackgroundService
+{
+    private static readonly Uri GitHubNotificationsUri = new("https://github.com/notifications");
+    private static readonly Uri GitHubTokenSettingsUri = new("https://github.com/settings/tokens");
+    private static readonly Uri RepositoryUri = new("https://github.com/credfeto/credfeto-dispatcher");
+
+    private readonly ICurrentTimeSource _currentTimeSource;
+    private readonly IDiscordDispatcher _discordDispatcher;
+    private readonly ILogger<StartupNotificationService> _logger;
+    private readonly IGitHubNotificationPoller _poller;
+
+    public StartupNotificationService(
+        IGitHubNotificationPoller poller,
+        IDiscordDispatcher discordDispatcher,
+        ICurrentTimeSource currentTimeSource,
+        ILogger<StartupNotificationService> logger
+    )
+    {
+        this._poller = poller;
+        this._discordDispatcher = discordDispatcher;
+        this._currentTimeSource = currentTimeSource;
+        this._logger = logger;
+    }
+
+    public override async Task StartAsync(CancellationToken cancellationToken)
+    {
+        this._logger.LogStartupNotificationServiceStarting();
+
+        try
+        {
+            DiscordMessage message = BuildAppStartedMessage(this._currentTimeSource.UtcNow());
+
+            await this._discordDispatcher.SendAsync(message: message, cancellationToken: cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            this._logger.LogStartupNotificationError(exception: exception);
+        }
+
+        await base.StartAsync(cancellationToken);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await this.CheckGitHubAuthAsync(stoppingToken);
+    }
+
+    private static DiscordMessage BuildAppStartedMessage(in DateTimeOffset timestamp)
+    {
+        string machineName = Environment.MachineName;
+        Assembly assembly = typeof(StartupNotificationService).Assembly;
+        string product = assembly.GetCustomAttribute<AssemblyProductAttribute>()?.Product ?? "Credfeto Dispatcher";
+        string version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                         ?? assembly.GetName().Version?.ToString()
+                         ?? "unknown";
+
+        DiscordEmbed embed = new(
+            Title: "Application started",
+            Description: $"Version: {version}\nHost: {machineName}\nStarted at: {timestamp:yyyy-MM-dd HH:mm:ss} UTC",
+            Url: RepositoryUri,
+            Color: 0x57F287
+        );
+
+        return new DiscordMessage(Content: $"**{product}** is starting up", Embeds: [embed]);
+    }
+
+    private async ValueTask CheckGitHubAuthAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await this._poller.PollAsync(cancellationToken);
+
+            this._logger.LogGitHubAuthenticationSuccessful();
+
+            await this.TrySendAuthSuccessMessageAsync(cancellationToken);
+        }
+        catch (HttpRequestException httpException) when (httpException.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+        {
+            int statusCode = (int)(httpException.StatusCode ?? HttpStatusCode.Unauthorized);
+
+            this._logger.LogGitHubAuthenticationFailed(statusCode: statusCode);
+
+            await this.TrySendAuthFailureMessageAsync(statusCode: statusCode, cancellationToken: cancellationToken);
+        }
+        catch (OperationCanceledException exception)
+        {
+            this._logger.LogStartupNotificationError(exception: exception);
+        }
+        catch (Exception exception)
+        {
+            this._logger.LogGitHubAuthCheckError(exception: exception);
+        }
+    }
+
+    private async ValueTask TrySendAuthSuccessMessageAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            DiscordEmbed embed = new(
+                Title: "GitHub authentication successful",
+                Description: "The GitHub token is valid and the notifications endpoint responded successfully.",
+                Url: GitHubNotificationsUri,
+                Color: 0x57F287
+            );
+
+            DiscordMessage message = new(Content: "\u2705 GitHub auth check passed", Embeds: [embed]);
+
+            await this._discordDispatcher.SendAsync(message: message, cancellationToken: cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            this._logger.LogStartupNotificationError(exception: exception);
+        }
+    }
+
+    private async ValueTask TrySendAuthFailureMessageAsync(int statusCode, CancellationToken cancellationToken)
+    {
+        try
+        {
+            DiscordEmbed embed = new(
+                Title: "GitHub authentication failed",
+                Description: $"HTTP {statusCode} received from the GitHub notifications endpoint. Check that the token is valid and has the `notifications` scope.",
+                Url: GitHubTokenSettingsUri,
+                Color: 0xED4245
+            );
+
+            DiscordMessage message = new(Content: "\u274c GitHub auth check failed", Embeds: [embed]);
+
+            await this._discordDispatcher.SendAsync(message: message, cancellationToken: cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            this._logger.LogStartupNotificationError(exception: exception);
+        }
+    }
+}

--- a/src/Credfeto.Dispatcher.GitHub/Credfeto.Dispatcher.GitHub.csproj
+++ b/src/Credfeto.Dispatcher.GitHub/Credfeto.Dispatcher.GitHub.csproj
@@ -48,6 +48,8 @@
     <ProjectReference Include="..\Credfeto.Dispatcher.Shared\Credfeto.Dispatcher.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Credfeto.Date" Version="1.1.150.1668" />
+    <PackageReference Include="Credfeto.Date.Interfaces" Version="1.1.150.1668" />
     <PackageReference Include="Credfeto.Services.Startup.Interfaces" Version="1.1.143.1554" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.6" />

--- a/src/Credfeto.Dispatcher.GitHub/GitHubSetup.cs
+++ b/src/Credfeto.Dispatcher.GitHub/GitHubSetup.cs
@@ -27,6 +27,7 @@ public static class GitHubSetup
             .Services
             .AddSingleton<INotificationPoller, NotificationPoller>()
             .AddSingleton<INotificationFilter, NotificationFilter>()
+            .AddHostedService<StartupNotificationService>()
             .AddHostedService<GitHubPollingWorker>();
     }
 


### PR DESCRIPTION
## Summary

Closes #7

- Posts startup and GitHub auth status messages to Discord when the service launches
- Provides visibility into service health and authentication state directly in Discord

## Test plan
- [x] Build passes (`dotnet build`)
- [x] All tests pass (`dotnet test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)