### PR TITLE
feat: enrich pull request notifications with GitHub API context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - `DiscordEmbedField` type and `Fields` collection on `DiscordEmbed` to support Discord embed field sections
 - Rich PR notification embeds in Discord with Status, Reason, Assignees, Labels, and context-specific fields
 - `FixedResponseHandler` HTTP test helper and comprehensive `PullRequestDetailFetcherTests` covering all enrichment paths, status determination, body truncation, and error cases
+- PR number, reason, and HTML URL included in the Discord message `Content` field for pull request notifications, making them actionable without reading the embed (e.g. `[owner/repo] PR #42 (mention) https://github.com/owner/repo/pull/42`)
+- `GitHubPollingWorkerTests` covering Content field format, fallback to basic message when fetcher returns null, issue notification format, and filtered notification not dispatched
 ### Fixed
 - Removed unused `Mediator` runtime package reference from `Credfeto.Dispatcher.Server` — `Mediator.SourceGenerator` source generator is sufficient; no separate runtime package is needed for a simple background service
 - Updated gitleaks configuration to suppress false positive secret detection caused by logging extension class name matching the GitHub token regex pattern

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Structured `ILogger<T>` logging throughout the polling and dispatch pipeline: worker startup/shutdown, poll cycles (ETag sent, 304 Not Modified or notification count), per-notification debug entries, filter pass/drop decisions, dispatch to Discord, and Discord webhook non-success warnings
 - Post startup and GitHub auth status messages to Discord on launch
 - AllowedRepos filter option to restrict notifications to specific repositories only
+- Pull request detail enrichment: `IPullRequestDetailFetcher` service that fetches PR title, status (Open/Draft/Closed), assignees, labels, latest comment (for `comment` reason), last CHANGES_REQUESTED review (for `review_requested` reason), and failed CI workflow run (for `ci_activity` reason)
+- `DiscordEmbedField` type and `Fields` collection on `DiscordEmbed` to support Discord embed field sections
+- Rich PR notification embeds in Discord with Status, Reason, Assignees, Labels, and context-specific fields
+- `FixedResponseHandler` HTTP test helper and comprehensive `PullRequestDetailFetcherTests` covering all enrichment paths, status determination, body truncation, and error cases
 ### Fixed
 - Removed unused `Mediator` runtime package reference from `Credfeto.Dispatcher.Server` — `Mediator.SourceGenerator` source generator is sufficient; no separate runtime package is needed for a simple background service
 - Updated gitleaks configuration to suppress false positive secret detection caused by logging extension class name matching the GitHub token regex pattern

--- a/src/Credfeto.Dispatcher.Discord.DataTypes/DiscordEmbed.cs
+++ b/src/Credfeto.Dispatcher.Discord.DataTypes/DiscordEmbed.cs
@@ -1,7 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Credfeto.Dispatcher.Discord.DataTypes;
 
 [DebuggerDisplay("{Title}: {Url}")]
-public sealed record DiscordEmbed(string Title, string Description, Uri Url, int Color);
+public sealed record DiscordEmbed(string Title, string Description, Uri Url, int Color, IReadOnlyList<DiscordEmbedField>? Fields = null);

--- a/src/Credfeto.Dispatcher.Discord.DataTypes/DiscordEmbedField.cs
+++ b/src/Credfeto.Dispatcher.Discord.DataTypes/DiscordEmbedField.cs
@@ -1,0 +1,6 @@
+using System.Diagnostics;
+
+namespace Credfeto.Dispatcher.Discord.DataTypes;
+
+[DebuggerDisplay("{Name}: {Value}")]
+public sealed record DiscordEmbedField(string Name, string Value, bool Inline);

--- a/src/Credfeto.Dispatcher.Discord/Services/DiscordWebhookDispatcher.cs
+++ b/src/Credfeto.Dispatcher.Discord/Services/DiscordWebhookDispatcher.cs
@@ -55,9 +55,27 @@ public sealed class DiscordWebhookDispatcher : IDiscordDispatcher
 
         foreach (DiscordEmbed embed in message.Embeds)
         {
-            embeds.Add(new DiscordWebhookEmbed(Title: embed.Title, Description: embed.Description, Url: embed.Url.ToString(), Color: embed.Color));
+            IReadOnlyList<DiscordWebhookField>? fields = MapFields(embed.Fields);
+            embeds.Add(new DiscordWebhookEmbed(Title: embed.Title, Description: embed.Description, Url: embed.Url.ToString(), Color: embed.Color, Fields: fields));
         }
 
         return new DiscordWebhookPayload(Content: message.Content, Embeds: embeds);
+    }
+
+    private static IReadOnlyList<DiscordWebhookField>? MapFields(IReadOnlyList<Discord.DataTypes.DiscordEmbedField>? fields)
+    {
+        if (fields is null || fields.Count == 0)
+        {
+            return null;
+        }
+
+        DiscordWebhookField[] result = new DiscordWebhookField[fields.Count];
+
+        for (int i = 0; i < fields.Count; i++)
+        {
+            result[i] = new DiscordWebhookField(Name: fields[i].Name, Value: fields[i].Value, Inline: fields[i].Inline);
+        }
+
+        return result;
     }
 }

--- a/src/Credfeto.Dispatcher.Discord/Services/DiscordWebhookEmbed.cs
+++ b/src/Credfeto.Dispatcher.Discord/Services/DiscordWebhookEmbed.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json.Serialization;
 
@@ -8,5 +9,6 @@ internal sealed record DiscordWebhookEmbed(
     [property: JsonPropertyName("title")] string Title,
     [property: JsonPropertyName("description")] string Description,
     [property: JsonPropertyName("url")] string Url,
-    [property: JsonPropertyName("color")] int Color
+    [property: JsonPropertyName("color")] int Color,
+    [property: JsonPropertyName("fields")] IReadOnlyList<DiscordWebhookField>? Fields
 );

--- a/src/Credfeto.Dispatcher.Discord/Services/DiscordWebhookField.cs
+++ b/src/Credfeto.Dispatcher.Discord/Services/DiscordWebhookField.cs
@@ -1,0 +1,11 @@
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace Credfeto.Dispatcher.Discord.Services;
+
+[DebuggerDisplay("{Name}: {Value}")]
+internal sealed record DiscordWebhookField(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("value")] string Value,
+    [property: JsonPropertyName("inline")] bool Inline
+);

--- a/src/Credfeto.Dispatcher.GitHub.DataTypes/PullRequestDetails.cs
+++ b/src/Credfeto.Dispatcher.GitHub.DataTypes/PullRequestDetails.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Credfeto.Dispatcher.GitHub.DataTypes;
+
+[DebuggerDisplay("{Number}: {Title} ({Status})")]
+public sealed record PullRequestDetails(
+    int Number,
+    string Title,
+    string Status,
+    Uri HtmlUrl,
+    IReadOnlyList<string> Assignees,
+    IReadOnlyList<string> Labels,
+    string? CommentBody,
+    string? CommentAuthor,
+    Uri? CommentUrl,
+    string? ReviewState,
+    string? ReviewBody,
+    string? ReviewAuthor,
+    Uri? ReviewUrl,
+    string? FailedRunName,
+    Uri? FailedRunUrl
+);

--- a/src/Credfeto.Dispatcher.GitHub.Interfaces/IPullRequestDetailFetcher.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Interfaces/IPullRequestDetailFetcher.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.Dispatcher.GitHub.DataTypes;
+
+namespace Credfeto.Dispatcher.GitHub.Interfaces;
+
+public interface IPullRequestDetailFetcher
+{
+    ValueTask<PullRequestDetails?> FetchAsync(GitHubNotification notification, CancellationToken cancellationToken);
+}

--- a/src/Credfeto.Dispatcher.GitHub.Tests/BackgroundServices/GitHubPollingWorkerTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/BackgroundServices/GitHubPollingWorkerTests.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.Dispatcher.Discord.DataTypes;
+using Credfeto.Dispatcher.Discord.Interfaces;
+using Credfeto.Dispatcher.GitHub.BackgroundServices;
+using Credfeto.Dispatcher.GitHub.Configuration;
+using Credfeto.Dispatcher.GitHub.DataTypes;
+using Credfeto.Dispatcher.GitHub.Interfaces;
+using FunFair.Test.Common;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Credfeto.Dispatcher.GitHub.Tests.BackgroundServices;
+
+public sealed class GitHubPollingWorkerTests : TestBase
+{
+    private readonly CapturingDiscordDispatcher _discord;
+    private readonly INotificationFilter _filter;
+
+    public GitHubPollingWorkerTests()
+    {
+        this._discord = new CapturingDiscordDispatcher();
+        this._filter = Substitute.For<INotificationFilter>();
+    }
+
+    private static GitHubNotification BuildPrNotification(string reason)
+    {
+        return new GitHubNotification(
+            Id: "1",
+            Reason: reason,
+            Subject: new NotificationSubject(Title: "Test PR", Url: new Uri("https://api.github.com/repos/owner/repo/pulls/42"), Type: "PullRequest"),
+            Repository: new NotificationRepository(FullName: "owner/repo", Url: new Uri("https://github.com/owner/repo")),
+            UpdatedAt: new DateTimeOffset(year: 2024, month: 1, day: 1, hour: 0, minute: 0, second: 0, offset: TimeSpan.Zero),
+            Unread: true);
+    }
+
+    private static GitHubNotification BuildIssueNotification()
+    {
+        return new GitHubNotification(
+            Id: "2",
+            Reason: "mention",
+            Subject: new NotificationSubject(Title: "Test Issue", Url: new Uri("https://api.github.com/repos/owner/repo/issues/10"), Type: "Issue"),
+            Repository: new NotificationRepository(FullName: "owner/repo", Url: new Uri("https://github.com/owner/repo")),
+            UpdatedAt: new DateTimeOffset(year: 2024, month: 1, day: 1, hour: 0, minute: 0, second: 0, offset: TimeSpan.Zero),
+            Unread: true);
+    }
+
+    private static PullRequestDetails BuildPrDetails()
+    {
+        return new PullRequestDetails(
+            Number: 42,
+            Title: "Test PR",
+            Status: "Open",
+            HtmlUrl: new Uri("https://github.com/owner/repo/pull/42"),
+            Assignees: [],
+            Labels: [],
+            CommentBody: null,
+            CommentAuthor: null,
+            CommentUrl: null,
+            ReviewState: null,
+            ReviewBody: null,
+            ReviewAuthor: null,
+            ReviewUrl: null,
+            FailedRunName: null,
+            FailedRunUrl: null);
+    }
+
+    private GitHubPollingWorker CreateWorker(INotificationPoller poller, IPullRequestDetailFetcher fetcher)
+    {
+        return new GitHubPollingWorker(
+            poller: poller,
+            notificationFilter: this._filter,
+            discordDispatcher: this._discord,
+            pullRequestDetailFetcher: fetcher,
+            options: Options.Create(new GitHubOptions { PollIntervalSeconds = 30 }),
+            logger: Substitute.For<ILogger<GitHubPollingWorker>>());
+    }
+
+    private async Task<DiscordMessage> RunAndCaptureAsync(INotificationPoller poller, IPullRequestDetailFetcher fetcher)
+    {
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        using GitHubPollingWorker worker = this.CreateWorker(poller: poller, fetcher: fetcher);
+        await worker.StartAsync(token);
+        DiscordMessage captured = await this._discord.Dispatched.WaitAsync(timeout: TimeSpan.FromSeconds(5), cancellationToken: token);
+        await worker.StopAsync(token);
+
+        return captured;
+    }
+
+    [Fact]
+    public async Task PullRequestMessageContentContainsNumberReasonAndUrlAsync()
+    {
+        GitHubNotification notification = BuildPrNotification("mention");
+        PullRequestDetails details = BuildPrDetails();
+
+        this._filter.ShouldDispatch(notification)
+                    .Returns(true);
+
+        DiscordMessage captured = await this.RunAndCaptureAsync(
+            poller: new FakePoller([notification]),
+            fetcher: new FakeFetcher(details));
+
+        Assert.Equal(expected: "[owner/repo] PR #42 (mention) https://github.com/owner/repo/pull/42", actual: captured.Content);
+    }
+
+    [Fact]
+    public async Task PullRequestMessageFallsBackToBasicWhenFetcherReturnsNullAsync()
+    {
+        GitHubNotification notification = BuildPrNotification("mention");
+
+        this._filter.ShouldDispatch(notification)
+                    .Returns(true);
+
+        DiscordMessage captured = await this.RunAndCaptureAsync(
+            poller: new FakePoller([notification]),
+            fetcher: new FakeFetcher(result: null));
+
+        Assert.Equal(expected: "[owner/repo] PullRequest", actual: captured.Content);
+    }
+
+    [Fact]
+    public async Task IssueNotificationUsesBasicMessageContentAsync()
+    {
+        GitHubNotification notification = BuildIssueNotification();
+
+        this._filter.ShouldDispatch(notification)
+                    .Returns(true);
+
+        DiscordMessage captured = await this.RunAndCaptureAsync(
+            poller: new FakePoller([notification]),
+            fetcher: new FakeFetcher(result: null));
+
+        Assert.Equal(expected: "[owner/repo] Issue", actual: captured.Content);
+    }
+
+    [Fact]
+    public async Task FilteredNotificationIsNotDispatchedAsync()
+    {
+        GitHubNotification notification = BuildPrNotification("mention");
+
+        this._filter.ShouldDispatch(notification)
+                    .Returns(false);
+
+        CancellationToken token = TestContext.Current.CancellationToken;
+        using GitHubPollingWorker worker = this.CreateWorker(poller: new FakePoller([notification]), fetcher: new FakeFetcher(result: null));
+        await worker.StartAsync(token);
+        await Task.Delay(millisecondsDelay: 200, cancellationToken: token);
+        await worker.StopAsync(token);
+
+        Assert.False(condition: this._discord.Dispatched.IsCompleted, userMessage: "Expected no message to be dispatched");
+    }
+
+    private sealed class FakePoller : INotificationPoller
+    {
+        private readonly IReadOnlyList<GitHubNotification> _notifications;
+
+        public FakePoller(IReadOnlyList<GitHubNotification> notifications)
+        {
+            this._notifications = notifications;
+        }
+
+        public ValueTask<IReadOnlyList<GitHubNotification>> PollAsync(CancellationToken cancellationToken)
+        {
+            return ValueTask.FromResult(this._notifications);
+        }
+    }
+
+    private sealed class FakeFetcher : IPullRequestDetailFetcher
+    {
+        private readonly PullRequestDetails? _result;
+
+        public FakeFetcher(PullRequestDetails? result)
+        {
+            this._result = result;
+        }
+
+        public ValueTask<PullRequestDetails?> FetchAsync(GitHubNotification notification, CancellationToken cancellationToken)
+        {
+            return ValueTask.FromResult(this._result);
+        }
+    }
+
+    private sealed class CapturingDiscordDispatcher : IDiscordDispatcher
+    {
+        private readonly TaskCompletionSource<DiscordMessage> _tcs = new();
+
+        public Task<DiscordMessage> Dispatched => this._tcs.Task;
+
+        public ValueTask SendAsync(DiscordMessage message, CancellationToken cancellationToken)
+        {
+            this._tcs.TrySetResult(message);
+
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Credfeto.Dispatcher.GitHub.Tests/GitHubSetupTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/GitHubSetupTests.cs
@@ -44,4 +44,16 @@ public sealed class GitHubSetupTests : DependencyInjectionTestsBase
     {
         this.RequireServiceInCollectionFor<INotificationFilter, NotificationFilter>();
     }
+
+    [Fact]
+    public void PullRequestDetailFetcherShouldBeRegistered()
+    {
+        this.RequireService<IPullRequestDetailFetcher>();
+    }
+
+    [Fact]
+    public void PullRequestDetailFetcherShouldBeOfCorrectType()
+    {
+        this.RequireServiceInCollectionFor<IPullRequestDetailFetcher, PullRequestDetailFetcher>();
+    }
 }

--- a/src/Credfeto.Dispatcher.GitHub.Tests/Helpers/FixedResponseHandler.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/Helpers/FixedResponseHandler.cs
@@ -1,0 +1,31 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Credfeto.Dispatcher.GitHub.Tests.Helpers;
+
+internal sealed class FixedResponseHandler : HttpMessageHandler
+{
+    private readonly HttpStatusCode _statusCode;
+    private readonly string? _content;
+
+    public FixedResponseHandler(HttpStatusCode statusCode, string? content = null)
+    {
+        this._statusCode = statusCode;
+        this._content = content;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = new(this._statusCode);
+
+        if (this._content is not null)
+        {
+            response.Content = new StringContent(content: this._content, encoding: Encoding.UTF8, mediaType: "application/json");
+        }
+
+        return Task.FromResult(response);
+    }
+}

--- a/src/Credfeto.Dispatcher.GitHub.Tests/Services/PullRequestDetailFetcherTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/Services/PullRequestDetailFetcherTests.cs
@@ -1,0 +1,455 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Credfeto.Dispatcher.GitHub.DataTypes;
+using Credfeto.Dispatcher.GitHub.Interfaces;
+using Credfeto.Dispatcher.GitHub.Services;
+using Credfeto.Dispatcher.GitHub.Tests.Helpers;
+using FunFair.Test.Common;
+using NSubstitute;
+using Xunit;
+
+namespace Credfeto.Dispatcher.GitHub.Tests.Services;
+
+public sealed class PullRequestDetailFetcherTests : TestBase
+{
+    private const string PrApiUrl = "https://api.github.com/repos/owner/repo/pulls/42";
+
+    private const string OpenPrJson =
+        """
+        {
+          "number": 42,
+          "title": "Test PR",
+          "state": "open",
+          "draft": false,
+          "html_url": "https://github.com/owner/repo/pull/42",
+          "assignees": [],
+          "labels": [],
+          "head": {"sha": "abc123"}
+        }
+        """;
+
+    private const string DraftPrJson =
+        """
+        {
+          "number": 42,
+          "title": "Test PR",
+          "state": "open",
+          "draft": true,
+          "html_url": "https://github.com/owner/repo/pull/42",
+          "assignees": [],
+          "labels": [],
+          "head": {"sha": "abc123"}
+        }
+        """;
+
+    private const string ClosedPrJson =
+        """
+        {
+          "number": 42,
+          "title": "Test PR",
+          "state": "closed",
+          "draft": false,
+          "html_url": "https://github.com/owner/repo/pull/42",
+          "assignees": [],
+          "labels": [],
+          "head": {"sha": "abc123"}
+        }
+        """;
+
+    private const string PrWithAssigneesJson =
+        """
+        {
+          "number": 42,
+          "title": "Test PR",
+          "state": "open",
+          "draft": false,
+          "html_url": "https://github.com/owner/repo/pull/42",
+          "assignees": [{"login": "alice"}, {"login": "bob"}],
+          "labels": [],
+          "head": {"sha": "abc123"}
+        }
+        """;
+
+    private const string PrWithLabelsJson =
+        """
+        {
+          "number": 42,
+          "title": "Test PR",
+          "state": "open",
+          "draft": false,
+          "html_url": "https://github.com/owner/repo/pull/42",
+          "assignees": [],
+          "labels": [{"name": "bug"}, {"name": "enhancement"}],
+          "head": {"sha": "abc123"}
+        }
+        """;
+
+    private const string CommentsJson =
+        """
+        [{
+          "body": "A test comment",
+          "user": {"login": "reviewer"},
+          "html_url": "https://github.com/owner/repo/issues/42#issuecomment-1"
+        }]
+        """;
+
+    private const string ReviewsWithChangesRequestedJson =
+        """
+        [{
+          "state": "CHANGES_REQUESTED",
+          "body": "Please fix this",
+          "user": {"login": "reviewer"},
+          "html_url": "https://github.com/owner/repo/pull/42#pullrequestreview-1"
+        }]
+        """;
+
+    private const string ReviewsApprovedJson =
+        """
+        [{
+          "state": "APPROVED",
+          "body": "Looks good",
+          "user": {"login": "reviewer"},
+          "html_url": "https://github.com/owner/repo/pull/42#pullrequestreview-1"
+        }]
+        """;
+
+    private const string WorkflowRunsWithFailureJson =
+        """
+        {
+          "workflow_runs": [{
+            "name": "CI",
+            "conclusion": "failure",
+            "html_url": "https://github.com/owner/repo/actions/runs/123"
+          }]
+        }
+        """;
+
+    private const string WorkflowRunsAllPassedJson =
+        """
+        {
+          "workflow_runs": [{
+            "name": "CI",
+            "conclusion": "success",
+            "html_url": "https://github.com/owner/repo/actions/runs/123"
+          }]
+        }
+        """;
+
+    private readonly System.Net.Http.IHttpClientFactory _httpClientFactory;
+    private readonly IPullRequestDetailFetcher _fetcher;
+
+    public PullRequestDetailFetcherTests()
+    {
+        this._httpClientFactory = Substitute.For<System.Net.Http.IHttpClientFactory>();
+        this._fetcher = new PullRequestDetailFetcher(this._httpClientFactory);
+    }
+
+    private static HttpClient CreateClient(HttpStatusCode statusCode, string? content = null)
+    {
+        FixedResponseHandler? handler = new(statusCode: statusCode, content: content);
+
+        try
+        {
+            HttpClient client = new(handler: handler, disposeHandler: true) { BaseAddress = new Uri("https://api.github.com/") };
+            handler = null;
+
+            return client;
+        }
+        finally
+        {
+            handler?.Dispose();
+        }
+    }
+
+    private static GitHubNotification BuildNotification(string type, string reason)
+    {
+        return new GitHubNotification(
+            Id: "1",
+            Reason: reason,
+            Subject: new NotificationSubject(Title: "Test PR", Url: new Uri(PrApiUrl), Type: type),
+            Repository: new NotificationRepository(FullName: "owner/repo", Url: new Uri("https://github.com/owner/repo")),
+            UpdatedAt: new DateTimeOffset(year: 2024, month: 1, day: 1, hour: 0, minute: 0, second: 0, offset: TimeSpan.Zero),
+            Unread: true);
+    }
+
+    [Fact]
+    public async Task ReturnsNullForNonPullRequestTypeAsync()
+    {
+        GitHubNotification notification = BuildNotification(type: "Issue", reason: "mention");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ReturnsNullWhenPullRequestApiFailsAsync()
+    {
+        using HttpClient client = CreateClient(HttpStatusCode.NotFound);
+        this._httpClientFactory.CreateClient("GitHub").Returns(client);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "mention");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ReturnsPullRequestDetailsForOpenPrAsync()
+    {
+        using HttpClient client = CreateClient(HttpStatusCode.OK, OpenPrJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(client);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "mention");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: "Open", actual: result.Status);
+    }
+
+    [Fact]
+    public async Task ReturnsPullRequestDetailsForDraftPrAsync()
+    {
+        using HttpClient client = CreateClient(HttpStatusCode.OK, DraftPrJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(client);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "mention");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: "Draft", actual: result.Status);
+    }
+
+    [Fact]
+    public async Task ReturnsPullRequestDetailsForClosedPrAsync()
+    {
+        using HttpClient client = CreateClient(HttpStatusCode.OK, ClosedPrJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(client);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "mention");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: "Closed", actual: result.Status);
+    }
+
+    [Fact]
+    public async Task MapsTitleFromPullRequestAsync()
+    {
+        using HttpClient client = CreateClient(HttpStatusCode.OK, OpenPrJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(client);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "mention");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: "Test PR", actual: result.Title);
+    }
+
+    [Fact]
+    public async Task MapsNumberFromPullRequestAsync()
+    {
+        using HttpClient client = CreateClient(HttpStatusCode.OK, OpenPrJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(client);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "mention");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: 42, actual: result.Number);
+    }
+
+    [Fact]
+    public async Task MapsHtmlUrlFromPullRequestAsync()
+    {
+        using HttpClient client = CreateClient(HttpStatusCode.OK, OpenPrJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(client);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "mention");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: new Uri("https://github.com/owner/repo/pull/42"), actual: result.HtmlUrl);
+    }
+
+    [Fact]
+    public async Task MapsAssigneesFromPullRequestAsync()
+    {
+        using HttpClient client = CreateClient(HttpStatusCode.OK, PrWithAssigneesJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(client);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "mention");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: 2, actual: result.Assignees.Count);
+        Assert.Contains(expected: "alice", collection: result.Assignees);
+        Assert.Contains(expected: "bob", collection: result.Assignees);
+    }
+
+    [Fact]
+    public async Task MapsLabelsFromPullRequestAsync()
+    {
+        using HttpClient client = CreateClient(HttpStatusCode.OK, PrWithLabelsJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(client);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "mention");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: 2, actual: result.Labels.Count);
+        Assert.Contains(expected: "bug", collection: result.Labels);
+        Assert.Contains(expected: "enhancement", collection: result.Labels);
+    }
+
+    [Fact]
+    public async Task FetchesLatestCommentWhenReasonIsCommentAsync()
+    {
+        using HttpClient prClient = CreateClient(HttpStatusCode.OK, OpenPrJson);
+        using HttpClient commentClient = CreateClient(HttpStatusCode.OK, CommentsJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, commentClient);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "comment");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: "A test comment", actual: result.CommentBody);
+        Assert.Equal(expected: "reviewer", actual: result.CommentAuthor);
+        Assert.Equal(expected: new Uri("https://github.com/owner/repo/issues/42#issuecomment-1"), actual: result.CommentUrl);
+    }
+
+    [Fact]
+    public async Task ReturnsNullCommentWhenCommentApiFailsAsync()
+    {
+        using HttpClient prClient = CreateClient(HttpStatusCode.OK, OpenPrJson);
+        using HttpClient failClient = CreateClient(HttpStatusCode.InternalServerError);
+        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, failClient);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "comment");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Null(result.CommentBody);
+        Assert.Null(result.CommentAuthor);
+        Assert.Null(result.CommentUrl);
+    }
+
+    [Fact]
+    public async Task ReturnsNullCommentWhenCommentListIsEmptyAsync()
+    {
+        using HttpClient prClient = CreateClient(HttpStatusCode.OK, OpenPrJson);
+        using HttpClient emptyClient = CreateClient(HttpStatusCode.OK, "[]");
+        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, emptyClient);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "comment");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Null(result.CommentBody);
+    }
+
+    [Fact]
+    public async Task FetchesReviewWhenReasonIsReviewRequestedAsync()
+    {
+        using HttpClient prClient = CreateClient(HttpStatusCode.OK, OpenPrJson);
+        using HttpClient reviewClient = CreateClient(HttpStatusCode.OK, ReviewsWithChangesRequestedJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, reviewClient);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "review_requested");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: "CHANGES_REQUESTED", actual: result.ReviewState);
+        Assert.Equal(expected: "Please fix this", actual: result.ReviewBody);
+        Assert.Equal(expected: "reviewer", actual: result.ReviewAuthor);
+    }
+
+    [Fact]
+    public async Task ReturnsNullReviewWhenNoChangesRequestedAsync()
+    {
+        using HttpClient prClient = CreateClient(HttpStatusCode.OK, OpenPrJson);
+        using HttpClient reviewClient = CreateClient(HttpStatusCode.OK, ReviewsApprovedJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, reviewClient);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "review_requested");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Null(result.ReviewState);
+        Assert.Null(result.ReviewBody);
+    }
+
+    [Fact]
+    public async Task FetchesFailedRunWhenReasonIsCiActivityAsync()
+    {
+        using HttpClient prClient = CreateClient(HttpStatusCode.OK, OpenPrJson);
+        using HttpClient runsClient = CreateClient(HttpStatusCode.OK, WorkflowRunsWithFailureJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, runsClient);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "ci_activity");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: "CI", actual: result.FailedRunName);
+        Assert.Equal(expected: new Uri("https://github.com/owner/repo/actions/runs/123"), actual: result.FailedRunUrl);
+    }
+
+    [Fact]
+    public async Task ReturnsNullFailedRunWhenAllRunsPassedAsync()
+    {
+        using HttpClient prClient = CreateClient(HttpStatusCode.OK, OpenPrJson);
+        using HttpClient runsClient = CreateClient(HttpStatusCode.OK, WorkflowRunsAllPassedJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, runsClient);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "ci_activity");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.Null(result.FailedRunName);
+        Assert.Null(result.FailedRunUrl);
+    }
+
+    [Fact]
+    public async Task TruncatesLongCommentBodyAsync()
+    {
+        string longBody = new(c: 'x', count: 400);
+        string commentsWithLongBody = $$"""
+                                        [{
+                                          "body": "{{longBody}}",
+                                          "user": {"login": "reviewer"},
+                                          "html_url": "https://github.com/owner/repo/issues/42#issuecomment-1"
+                                        }]
+                                        """;
+
+        using HttpClient prClient = CreateClient(HttpStatusCode.OK, OpenPrJson);
+        using HttpClient commentClient = CreateClient(HttpStatusCode.OK, commentsWithLongBody);
+        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, commentClient);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "comment");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(notification: notification, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.CommentBody);
+        Assert.Equal(expected: 301, actual: result.CommentBody.Length);
+        Assert.True(result.CommentBody.EndsWith('…'), userMessage: "Expected body to end with ellipsis");
+    }
+}

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/GitHubPollingWorker.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/GitHubPollingWorker.cs
@@ -160,7 +160,7 @@ public sealed class GitHubPollingWorker : BackgroundService
             Fields: fields
         );
 
-        return new DiscordMessage(Content: $"[{notification.Repository.FullName}] Pull Request", Embeds: [embed]);
+        return new DiscordMessage(Content: $"[{notification.Repository.FullName}] PR #{details.Number} ({notification.Reason}) {details.HtmlUrl}", Embeds: [embed]);
     }
 
     private static string FormatReason(string reason)

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/GitHubPollingWorker.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/GitHubPollingWorker.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Credfeto.Dispatcher.Discord.DataTypes;
 using Credfeto.Dispatcher.Discord.Interfaces;
 using Credfeto.Dispatcher.GitHub.BackgroundServices.LoggingExtensions;
 using Credfeto.Dispatcher.GitHub.Configuration;
@@ -15,16 +16,21 @@ namespace Credfeto.Dispatcher.GitHub.BackgroundServices;
 
 public sealed class GitHubPollingWorker : BackgroundService
 {
+    private const string PullRequestType = "PullRequest";
+    private const int EmbedColour = 0x5865F2;
+
     private readonly IDiscordDispatcher _discordDispatcher;
     private readonly ILogger<GitHubPollingWorker> _logger;
     private readonly INotificationFilter _notificationFilter;
     private readonly GitHubOptions _options;
     private readonly INotificationPoller _poller;
+    private readonly IPullRequestDetailFetcher _pullRequestDetailFetcher;
 
     public GitHubPollingWorker(
         INotificationPoller poller,
         INotificationFilter notificationFilter,
         IDiscordDispatcher discordDispatcher,
+        IPullRequestDetailFetcher pullRequestDetailFetcher,
         IOptions<GitHubOptions> options,
         ILogger<GitHubPollingWorker> logger
     )
@@ -32,6 +38,7 @@ public sealed class GitHubPollingWorker : BackgroundService
         this._poller = poller;
         this._notificationFilter = notificationFilter;
         this._discordDispatcher = discordDispatcher;
+        this._pullRequestDetailFetcher = pullRequestDetailFetcher;
         this._options = options.Value;
         this._logger = logger;
     }
@@ -78,21 +85,97 @@ public sealed class GitHubPollingWorker : BackgroundService
 
             this._logger.LogDispatchingNotification(notificationId: notification.Id, repository: notification.Repository.FullName, title: notification.Subject.Title);
 
-            Discord.DataTypes.DiscordMessage message = BuildDiscordMessage(notification);
+            DiscordMessage message = await this.BuildDiscordMessageAsync(notification: notification, cancellationToken: cancellationToken);
 
             await this._discordDispatcher.SendAsync(message: message, cancellationToken: cancellationToken);
         }
     }
 
-    private static Discord.DataTypes.DiscordMessage BuildDiscordMessage(GitHubNotification notification)
+    private async ValueTask<DiscordMessage> BuildDiscordMessageAsync(GitHubNotification notification, CancellationToken cancellationToken)
     {
-        Discord.DataTypes.DiscordEmbed embed = new(
+        if (string.Equals(a: notification.Subject.Type, b: PullRequestType, comparisonType: StringComparison.OrdinalIgnoreCase))
+        {
+            PullRequestDetails? details = await this._pullRequestDetailFetcher.FetchAsync(notification: notification, cancellationToken: cancellationToken);
+
+            if (details is not null)
+            {
+                return BuildPullRequestMessage(notification: notification, details: details);
+            }
+        }
+
+        return BuildBasicMessage(notification);
+    }
+
+    private static DiscordMessage BuildBasicMessage(GitHubNotification notification)
+    {
+        DiscordEmbed embed = new(
             Title: notification.Subject.Title,
             Description: $"Reason: {notification.Reason}",
             Url: notification.Subject.Url,
-            Color: 0x5865F2
+            Color: EmbedColour
         );
 
-        return new Discord.DataTypes.DiscordMessage(Content: $"[{notification.Repository.FullName}] {notification.Subject.Type}", Embeds: [embed]);
+        return new DiscordMessage(Content: $"[{notification.Repository.FullName}] {notification.Subject.Type}", Embeds: [embed]);
+    }
+
+    private static DiscordMessage BuildPullRequestMessage(GitHubNotification notification, PullRequestDetails details)
+    {
+        List<DiscordEmbedField> fields =
+        [
+            new DiscordEmbedField(Name: "Status", Value: details.Status, Inline: true),
+            new DiscordEmbedField(Name: "Reason", Value: FormatReason(notification.Reason), Inline: true),
+        ];
+
+        if (details.Assignees.Count > 0)
+        {
+            fields.Add(new DiscordEmbedField(Name: "Assigned to", Value: string.Join(separator: ", ", values: details.Assignees), Inline: true));
+        }
+
+        if (details.Labels.Count > 0)
+        {
+            fields.Add(new DiscordEmbedField(Name: "Labels", Value: string.Join(separator: ", ", values: details.Labels), Inline: true));
+        }
+
+        if (details.CommentBody is not null)
+        {
+            fields.Add(new DiscordEmbedField(Name: $"Comment by {details.CommentAuthor}", Value: details.CommentUrl is not null ? $"[View comment]({details.CommentUrl})\n{details.CommentBody}" : details.CommentBody, Inline: false));
+        }
+
+        if (details.ReviewBody is not null)
+        {
+            string reviewHeader = details.ReviewState is not null ? $"Review ({details.ReviewState}) by {details.ReviewAuthor}" : $"Review by {details.ReviewAuthor}";
+            fields.Add(new DiscordEmbedField(Name: reviewHeader, Value: details.ReviewUrl is not null ? $"[View review]({details.ReviewUrl})\n{details.ReviewBody}" : details.ReviewBody, Inline: false));
+        }
+
+        if (details.FailedRunName is not null && details.FailedRunUrl is not null)
+        {
+            fields.Add(new DiscordEmbedField(Name: "Failed CI Run", Value: $"[{details.FailedRunName}]({details.FailedRunUrl})", Inline: false));
+        }
+
+        DiscordEmbed embed = new(
+            Title: details.Title,
+            Description: $"PR #{details.Number} in {notification.Repository.FullName}",
+            Url: details.HtmlUrl,
+            Color: EmbedColour,
+            Fields: fields
+        );
+
+        return new DiscordMessage(Content: $"[{notification.Repository.FullName}] Pull Request", Embeds: [embed]);
+    }
+
+    private static string FormatReason(string reason)
+    {
+        return reason switch
+        {
+            "assign" => "Assigned to you",
+            "author" => "You are the author",
+            "comment" => "New comment",
+            "mention" => "You were mentioned",
+            "review_requested" => "Review requested",
+            "changes_requested" => "Changes requested",
+            "ci_activity" => "CI activity",
+            "subscribed" => "Subscribed",
+            _ => reason
+        };
     }
 }

--- a/src/Credfeto.Dispatcher.GitHub/GitHubSetup.cs
+++ b/src/Credfeto.Dispatcher.GitHub/GitHubSetup.cs
@@ -27,6 +27,7 @@ public static class GitHubSetup
             .Services
             .AddSingleton<INotificationPoller, NotificationPoller>()
             .AddSingleton<INotificationFilter, NotificationFilter>()
+            .AddSingleton<IPullRequestDetailFetcher, PullRequestDetailFetcher>()
             .AddHostedService<StartupNotificationService>()
             .AddHostedService<GitHubPollingWorker>();
     }

--- a/src/Credfeto.Dispatcher.GitHub/Models/ApiIssueComment.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Models/ApiIssueComment.cs
@@ -1,0 +1,11 @@
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace Credfeto.Dispatcher.GitHub.Models;
+
+[DebuggerDisplay("{User.Login}: {Body}")]
+internal sealed record ApiIssueComment(
+    [property: JsonPropertyName("body")] string Body,
+    [property: JsonPropertyName("user")] ApiUser User,
+    [property: JsonPropertyName("html_url")] string HtmlUrl
+);

--- a/src/Credfeto.Dispatcher.GitHub/Models/ApiLabel.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Models/ApiLabel.cs
@@ -1,0 +1,7 @@
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace Credfeto.Dispatcher.GitHub.Models;
+
+[DebuggerDisplay("{Name}")]
+internal sealed record ApiLabel([property: JsonPropertyName("name")] string Name);

--- a/src/Credfeto.Dispatcher.GitHub/Models/ApiPullRequest.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Models/ApiPullRequest.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace Credfeto.Dispatcher.GitHub.Models;
+
+[DebuggerDisplay("{Number}: {Title} ({State})")]
+internal sealed record ApiPullRequest(
+    [property: JsonPropertyName("number")] int Number,
+    [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("state")] string State,
+    [property: JsonPropertyName("draft")] bool Draft,
+    [property: JsonPropertyName("html_url")] string HtmlUrl,
+    [property: JsonPropertyName("assignees")] IReadOnlyList<ApiUser> Assignees,
+    [property: JsonPropertyName("labels")] IReadOnlyList<ApiLabel> Labels,
+    [property: JsonPropertyName("head")] ApiPullRequestHead Head
+);

--- a/src/Credfeto.Dispatcher.GitHub/Models/ApiPullRequestHead.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Models/ApiPullRequestHead.cs
@@ -1,0 +1,7 @@
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace Credfeto.Dispatcher.GitHub.Models;
+
+[DebuggerDisplay("{Sha}")]
+internal sealed record ApiPullRequestHead([property: JsonPropertyName("sha")] string Sha);

--- a/src/Credfeto.Dispatcher.GitHub/Models/ApiPullRequestReview.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Models/ApiPullRequestReview.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace Credfeto.Dispatcher.GitHub.Models;
+
+[DebuggerDisplay("{State}: {User.Login}")]
+internal sealed record ApiPullRequestReview(
+    [property: JsonPropertyName("state")] string State,
+    [property: JsonPropertyName("body")] string Body,
+    [property: JsonPropertyName("user")] ApiUser User,
+    [property: JsonPropertyName("html_url")] string HtmlUrl
+);

--- a/src/Credfeto.Dispatcher.GitHub/Models/ApiUser.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Models/ApiUser.cs
@@ -1,0 +1,7 @@
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace Credfeto.Dispatcher.GitHub.Models;
+
+[DebuggerDisplay("{Login}")]
+internal sealed record ApiUser([property: JsonPropertyName("login")] string Login);

--- a/src/Credfeto.Dispatcher.GitHub/Models/ApiWorkflowRun.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Models/ApiWorkflowRun.cs
@@ -1,0 +1,11 @@
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace Credfeto.Dispatcher.GitHub.Models;
+
+[DebuggerDisplay("{Name}: {Conclusion}")]
+internal sealed record ApiWorkflowRun(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("conclusion")] string? Conclusion,
+    [property: JsonPropertyName("html_url")] string HtmlUrl
+);

--- a/src/Credfeto.Dispatcher.GitHub/Models/ApiWorkflowRunsResponse.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Models/ApiWorkflowRunsResponse.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace Credfeto.Dispatcher.GitHub.Models;
+
+[DebuggerDisplay("{WorkflowRuns.Count} runs")]
+internal sealed record ApiWorkflowRunsResponse(
+    [property: JsonPropertyName("workflow_runs")] IReadOnlyList<ApiWorkflowRun> WorkflowRuns
+);

--- a/src/Credfeto.Dispatcher.GitHub/Models/NotificationSerializerContext.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Models/NotificationSerializerContext.cs
@@ -3,5 +3,9 @@ using System.Text.Json.Serialization;
 namespace Credfeto.Dispatcher.GitHub.Models;
 
 [JsonSerializable(typeof(ApiNotification[]))]
+[JsonSerializable(typeof(ApiPullRequest))]
+[JsonSerializable(typeof(ApiPullRequestReview[]))]
+[JsonSerializable(typeof(ApiIssueComment[]))]
+[JsonSerializable(typeof(ApiWorkflowRunsResponse))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 internal sealed partial class NotificationSerializerContext : JsonSerializerContext;

--- a/src/Credfeto.Dispatcher.GitHub/Services/PullRequestDetailFetcher.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Services/PullRequestDetailFetcher.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.Dispatcher.GitHub.DataTypes;
+using Credfeto.Dispatcher.GitHub.Interfaces;
+using Credfeto.Dispatcher.GitHub.Models;
+
+namespace Credfeto.Dispatcher.GitHub.Services;
+
+public sealed class PullRequestDetailFetcher : IPullRequestDetailFetcher
+{
+    private const string PullRequestType = "PullRequest";
+    private const string CommentReason = "comment";
+    private const string ReviewRequestedReason = "review_requested";
+    private const string ChangesRequestedState = "CHANGES_REQUESTED";
+    private const string CiActivityReason = "ci_activity";
+    private const int MaxBodyLength = 300;
+
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public PullRequestDetailFetcher(IHttpClientFactory httpClientFactory)
+    {
+        this._httpClientFactory = httpClientFactory;
+    }
+
+    public async ValueTask<PullRequestDetails?> FetchAsync(GitHubNotification notification, CancellationToken cancellationToken)
+    {
+        if (!string.Equals(a: notification.Subject.Type, b: PullRequestType, comparisonType: StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        string apiUrl = notification.Subject.Url.ToString();
+        ApiPullRequest? pr = await this.GetAsync<ApiPullRequest>(url: apiUrl, jsonTypeInfo: NotificationSerializerContext.Default.ApiPullRequest, cancellationToken: cancellationToken);
+
+        if (pr is null)
+        {
+            return null;
+        }
+
+        (string? commentBody, string? commentAuthor, Uri? commentUrl) = await this.FetchCommentAsync(notification: notification, apiUrl: apiUrl, cancellationToken: cancellationToken);
+        (string? reviewState, string? reviewBody, string? reviewAuthor, Uri? reviewUrl) = await this.FetchReviewAsync(notification: notification, apiUrl: apiUrl, cancellationToken: cancellationToken);
+        (string? failedRunName, Uri? failedRunUrl) = await this.FetchFailedRunAsync(notification: notification, pr: pr, cancellationToken: cancellationToken);
+
+        return new PullRequestDetails(
+            Number: pr.Number,
+            Title: pr.Title,
+            Status: DetermineStatus(pr),
+            HtmlUrl: new Uri(pr.HtmlUrl),
+            Assignees: [..pr.Assignees.Select(u => u.Login)],
+            Labels: [..pr.Labels.Select(l => l.Name)],
+            CommentBody: commentBody,
+            CommentAuthor: commentAuthor,
+            CommentUrl: commentUrl,
+            ReviewState: reviewState,
+            ReviewBody: reviewBody,
+            ReviewAuthor: reviewAuthor,
+            ReviewUrl: reviewUrl,
+            FailedRunName: failedRunName,
+            FailedRunUrl: failedRunUrl
+        );
+    }
+
+    private async ValueTask<(string? body, string? author, Uri? url)> FetchCommentAsync(GitHubNotification notification, string apiUrl, CancellationToken cancellationToken)
+    {
+        if (!string.Equals(a: notification.Reason, b: CommentReason, comparisonType: StringComparison.OrdinalIgnoreCase))
+        {
+            return (null, null, null);
+        }
+
+        string commentsUrl = BuildCommentsUrl(apiUrl);
+        ApiIssueComment[]? comments = await this.GetAsync<ApiIssueComment[]>(url: commentsUrl, jsonTypeInfo: NotificationSerializerContext.Default.ApiIssueCommentArray, cancellationToken: cancellationToken);
+        ApiIssueComment? latest = comments?.LastOrDefault();
+
+        if (latest is null)
+        {
+            return (null, null, null);
+        }
+
+        return (TruncateBody(latest.Body), latest.User.Login, new Uri(latest.HtmlUrl));
+    }
+
+    private async ValueTask<(string? state, string? body, string? author, Uri? url)> FetchReviewAsync(GitHubNotification notification, string apiUrl, CancellationToken cancellationToken)
+    {
+        if (!string.Equals(a: notification.Reason, b: ReviewRequestedReason, comparisonType: StringComparison.OrdinalIgnoreCase))
+        {
+            return (null, null, null, null);
+        }
+
+        string reviewsUrl = BuildReviewsUrl(apiUrl);
+        ApiPullRequestReview[]? reviews = await this.GetAsync<ApiPullRequestReview[]>(url: reviewsUrl, jsonTypeInfo: NotificationSerializerContext.Default.ApiPullRequestReviewArray, cancellationToken: cancellationToken);
+        ApiPullRequestReview? changesRequested = reviews?.LastOrDefault(r => string.Equals(a: r.State, b: ChangesRequestedState, comparisonType: StringComparison.OrdinalIgnoreCase));
+
+        if (changesRequested is null)
+        {
+            return (null, null, null, null);
+        }
+
+        return (changesRequested.State, TruncateBody(changesRequested.Body), changesRequested.User.Login, new Uri(changesRequested.HtmlUrl));
+    }
+
+    private async ValueTask<(string? name, Uri? url)> FetchFailedRunAsync(GitHubNotification notification, ApiPullRequest pr, CancellationToken cancellationToken)
+    {
+        if (!string.Equals(a: notification.Reason, b: CiActivityReason, comparisonType: StringComparison.OrdinalIgnoreCase))
+        {
+            return (null, null);
+        }
+
+        string runsUrl = BuildWorkflowRunsUrl(repoFullName: notification.Repository.FullName, headSha: pr.Head.Sha);
+        ApiWorkflowRunsResponse? runsResponse = await this.GetAsync<ApiWorkflowRunsResponse>(url: runsUrl, jsonTypeInfo: NotificationSerializerContext.Default.ApiWorkflowRunsResponse, cancellationToken: cancellationToken);
+        ApiWorkflowRun? failedRun = runsResponse?.WorkflowRuns.FirstOrDefault(r => string.Equals(a: r.Conclusion, b: "failure", comparisonType: StringComparison.OrdinalIgnoreCase));
+
+        if (failedRun is null)
+        {
+            return (null, null);
+        }
+
+        return (failedRun.Name, new Uri(failedRun.HtmlUrl));
+    }
+
+    private static string DetermineStatus(ApiPullRequest pr)
+    {
+        if (string.Equals(a: pr.State, b: "closed", comparisonType: StringComparison.OrdinalIgnoreCase))
+        {
+            return "Closed";
+        }
+
+        return pr.Draft ? "Draft" : "Open";
+    }
+
+    private static string BuildCommentsUrl(string pullRequestApiUrl)
+    {
+        return pullRequestApiUrl.Replace(oldValue: "/pulls/", newValue: "/issues/", comparisonType: StringComparison.Ordinal) + "/comments?per_page=1&direction=desc";
+    }
+
+    private static string BuildReviewsUrl(string pullRequestApiUrl)
+    {
+        return pullRequestApiUrl + "/reviews?per_page=10";
+    }
+
+    private static string BuildWorkflowRunsUrl(string repoFullName, string headSha)
+    {
+        return $"repos/{repoFullName}/actions/runs?head_sha={headSha}&per_page=10";
+    }
+
+    private static string TruncateBody(string body)
+    {
+        return body.Length <= MaxBodyLength ? body : body[..MaxBodyLength] + "…";
+    }
+
+    private async ValueTask<T?> GetAsync<T>(string url, System.Text.Json.Serialization.Metadata.JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken)
+        where T : class
+    {
+        HttpClient httpClient = this._httpClientFactory.CreateClient("GitHub");
+
+        using HttpRequestMessage request = new(method: HttpMethod.Get, requestUri: url);
+        using HttpResponseMessage response = await httpClient.SendAsync(request: request, cancellationToken: cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        string json = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        return JsonSerializer.Deserialize(json: json, jsonTypeInfo: jsonTypeInfo);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `IPullRequestDetailFetcher` service that fetches PR title, status (Open/Draft/Closed), assignees, labels, and context-specific enrichment based on notification reason
- For `reason=comment`: fetches latest comment body, author, and URL
- For `reason=review_requested`: fetches last CHANGES_REQUESTED review body, reviewer, and URL  
- For `reason=ci_activity`: fetches the failed CI workflow run name and URL
- Discord embeds now render rich field sections (Status, Reason, Assignees, Labels) for PR notifications, plus optional Comment/Review/CI fields when relevant
- Adds `DiscordEmbedField` type and `Fields` collection on `DiscordEmbed` for Discord embed field support
- Comprehensive `PullRequestDetailFetcherTests` with 18 tests covering all enrichment paths, status determination, body truncation at 300 chars, and API error fallback

## Test plan

- [x] Build passes with zero warnings/errors
- [x] `PullRequestDetailFetcherTests` — 18 tests covering open/draft/closed status, assignees, labels, comment enrichment, review enrichment, CI run enrichment, API error fallback, body truncation
- [x] `GitHubSetupTests` — `IPullRequestDetailFetcher` registration verified
- [x] All 73 tests across all test projects pass

Resolves #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)