### PR TITLE
feat: persist GitHub notifications API ETag in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - PR number, reason, and HTML URL included in the Discord message `Content` field for pull request notifications, making them actionable without reading the embed (e.g. `[owner/repo] PR #42 (mention) https://github.com/owner/repo/pull/42`)
 - `GitHubPollingWorkerTests` covering Content field format, fallback to basic message when fetcher returns null, issue notification format, and filtered notification not dispatched
 - SQLite database infrastructure using Entity Framework Core with automatic migration on startup; data folder created next to the application executable and git-ignored
+- Persist GitHub notifications API ETag in database to resume polling after restart (#21)
 ### Fixed
 - Removed unused `Mediator` runtime package reference from `Credfeto.Dispatcher.Server` — `Mediator.SourceGenerator` source generator is sufficient; no separate runtime package is needed for a simple background service
 - Updated gitleaks configuration to suppress false positive secret detection caused by logging extension class name matching the GitHub token regex pattern

--- a/ai/global/dotnet.instructions.md
+++ b/ai/global/dotnet.instructions.md
@@ -91,8 +91,40 @@ When writing tests with `FunFair.Test.Common.TestBase`, use the helper methods p
 - Never call `Substitute.For<T>()` directly in test classes that derive from `TestBase` or `DependencyInjectionTestsBase`.
 - Use `GetSubstitute<T>()` (no `this.` prefix — it is a static method) for all interface/class mocks.
 - Use `this.GetTypedLogger<T>()` (with `this.` prefix — it is an instance method) for `ILogger<T>` mocks.
-- If a mock is needed inside a `static` method (e.g. a DI registration factory passed to a base constructor), create a concrete no-op inner class instead of using `Substitute.For<T>()`.
 - Remove unused `using NSubstitute;` statements from files where all `Substitute.For<>()` calls have been replaced.
+
+## DI Setup Test Patterns
+
+When writing DI setup tests that derive from `DependencyInjectionTestsBase`, use `AddMockedService<T>()` from `FunFair.Test.Common` to register mocks.
+
+### Registering mocked services
+
+Use `.AddMockedService<T>()` instead of creating concrete inner classes or calling `Substitute.For<T>()` manually:
+
+```csharp
+// ✅ Correct
+private static IServiceCollection Configure(IServiceCollection services)
+{
+    return services.AddMyModule()
+                   .AddMockedService<IFoo>()
+                   .AddMockedService<IBar>();
+}
+```
+
+### Registering mocked IOptions\<T\>
+
+Use `.AddMockedService<IOptions<TOptions>>(static o => o.Value.Returns(new TOptions()))` instead of `Options.Create(...)`:
+
+```csharp
+// ✅ Correct
+.AddMockedService<IOptions<MyOptions>>(static o => o.Value.Returns(new MyOptions()))
+
+// ❌ Wrong
+.AddSingleton<IOptions<MyOptions>>(Options.Create(new MyOptions()))
+```
+
+- Never create concrete no-op inner classes to satisfy DI mocking in setup tests.
+- `GetSubstitute<T>()` is safe to call from `static` Configure methods (it is a static method).
 
 ## Source File Organisation
 

--- a/ai/global/dotnet.instructions.md
+++ b/ai/global/dotnet.instructions.md
@@ -77,6 +77,23 @@ Never push code that does not compile. If you cannot fix a build error, report i
 - All test projects must import the latest release version of the `FunFair.Test.Source.Generator` source generator package.
 - Test fixture classes must derive from `FunFair.Test.Common.TestBase`.
 
+## NSubstitute and FunFair.Test.Common Patterns
+
+When writing tests with `FunFair.Test.Common.TestBase`, use the helper methods provided by the base class instead of calling NSubstitute directly:
+
+| Instead of | Use |
+|---|---|
+| `Substitute.For<IMyInterface>()` | `GetSubstitute<IMyInterface>()` (static — no `this.`) |
+| `Substitute.For<ILogger<MyClass>>()` | `this.GetTypedLogger<MyClass>()` (instance — requires `this.`) |
+
+### Rules
+
+- Never call `Substitute.For<T>()` directly in test classes that derive from `TestBase` or `DependencyInjectionTestsBase`.
+- Use `GetSubstitute<T>()` (no `this.` prefix — it is a static method) for all interface/class mocks.
+- Use `this.GetTypedLogger<T>()` (with `this.` prefix — it is an instance method) for `ILogger<T>` mocks.
+- If a mock is needed inside a `static` method (e.g. a DI registration factory passed to a base constructor), create a concrete no-op inner class instead of using `Substitute.For<T>()`.
+- Remove unused `using NSubstitute;` statements from files where all `Substitute.For<>()` calls have been replaced.
+
 ## Source File Organisation
 
 - **One type per file**: every C# source file must contain exactly one type (class, record, struct, interface, or enum). Do not define multiple types in a single file.

--- a/src/Credfeto.Dispatcher.Discord.Tests/DiscordSetupTests.cs
+++ b/src/Credfeto.Dispatcher.Discord.Tests/DiscordSetupTests.cs
@@ -4,6 +4,7 @@ using Credfeto.Dispatcher.Discord.Services;
 using FunFair.Test.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 using Xunit;
 
 namespace Credfeto.Dispatcher.Discord.Tests;
@@ -18,7 +19,7 @@ public sealed class DiscordSetupTests : DependencyInjectionTestsBase
     private static IServiceCollection Configure(IServiceCollection services)
     {
         return services.AddDiscord()
-                       .AddSingleton<IOptions<DiscordOptions>>(Options.Create(new DiscordOptions()));
+                       .AddMockedService<IOptions<DiscordOptions>>(static o => o.Value.Returns(new DiscordOptions()));
     }
 
     [Fact]

--- a/src/Credfeto.Dispatcher.Discord.Tests/Services/DiscordWebhookDispatcherTests.cs
+++ b/src/Credfeto.Dispatcher.Discord.Tests/Services/DiscordWebhookDispatcherTests.cs
@@ -8,7 +8,6 @@ using Credfeto.Dispatcher.Discord.Interfaces;
 using Credfeto.Dispatcher.Discord.Services;
 using FunFair.Test.Common;
 using FunFair.Test.Common.Extensions;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
@@ -24,17 +23,17 @@ public sealed class DiscordWebhookDispatcherTests : TestBase
 
     public DiscordWebhookDispatcherTests()
     {
-        this._httpClientFactory = Substitute.For<IHttpClientFactory>();
+        this._httpClientFactory = GetSubstitute<IHttpClientFactory>();
 
         DiscordOptions options = new() { WebhookUrl = WebhookUrl };
-        this._dispatcher = new DiscordWebhookDispatcher(httpClientFactory: this._httpClientFactory, options: Options.Create(options), logger: Substitute.For<ILogger<DiscordWebhookDispatcher>>());
+        this._dispatcher = new DiscordWebhookDispatcher(httpClientFactory: this._httpClientFactory, options: Options.Create(options), logger: this.GetTypedLogger<DiscordWebhookDispatcher>());
     }
 
     [Fact]
     public async Task SendAsyncDoesNotCallHttpClientWhenWebhookUrlIsNullAsync()
     {
         DiscordOptions optionsWithNoWebhook = new() { WebhookUrl = null };
-        IDiscordDispatcher dispatcher = new DiscordWebhookDispatcher(httpClientFactory: this._httpClientFactory, options: Options.Create(optionsWithNoWebhook), logger: Substitute.For<ILogger<DiscordWebhookDispatcher>>());
+        IDiscordDispatcher dispatcher = new DiscordWebhookDispatcher(httpClientFactory: this._httpClientFactory, options: Options.Create(optionsWithNoWebhook), logger: this.GetTypedLogger<DiscordWebhookDispatcher>());
 
         DiscordMessage message = new(Content: "Hello", Embeds: []);
 

--- a/src/Credfeto.Dispatcher.GitHub.Interfaces/IETagStore.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Interfaces/IETagStore.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Credfeto.Dispatcher.GitHub.Interfaces;
+
+public interface IETagStore
+{
+    ValueTask<string?> GetETagAsync(string key, CancellationToken cancellationToken);
+
+    ValueTask SaveETagAsync(string key, string eTag, CancellationToken cancellationToken);
+}

--- a/src/Credfeto.Dispatcher.GitHub.Tests/BackgroundServices/GitHubPollingWorkerTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/BackgroundServices/GitHubPollingWorkerTests.cs
@@ -24,7 +24,7 @@ public sealed class GitHubPollingWorkerTests : TestBase
     public GitHubPollingWorkerTests()
     {
         this._discord = new CapturingDiscordDispatcher();
-        this._filter = Substitute.For<INotificationFilter>();
+        this._filter = GetSubstitute<INotificationFilter>();
     }
 
     private static GitHubNotification BuildPrNotification(string reason)
@@ -77,7 +77,7 @@ public sealed class GitHubPollingWorkerTests : TestBase
             discordDispatcher: this._discord,
             pullRequestDetailFetcher: fetcher,
             options: Options.Create(new GitHubOptions { PollIntervalSeconds = 30 }),
-            logger: Substitute.For<ILogger<GitHubPollingWorker>>());
+            logger: this.GetTypedLogger<GitHubPollingWorker>());
     }
 
     private async Task<DiscordMessage> RunAndCaptureAsync(INotificationPoller poller, IPullRequestDetailFetcher fetcher)

--- a/src/Credfeto.Dispatcher.GitHub.Tests/GitHubSetupTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/GitHubSetupTests.cs
@@ -1,10 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 using Credfeto.Dispatcher.GitHub.Configuration;
 using Credfeto.Dispatcher.GitHub.Interfaces;
 using Credfeto.Dispatcher.GitHub.Services;
 using FunFair.Test.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using NSubstitute;
 using Xunit;
 
 namespace Credfeto.Dispatcher.GitHub.Tests;
@@ -20,7 +22,21 @@ public sealed class GitHubSetupTests : DependencyInjectionTestsBase
     {
         return services.AddGitHub()
                        .AddSingleton<IOptions<GitHubOptions>>(Options.Create(new GitHubOptions()))
-                       .AddSingleton(Substitute.For<IETagStore>());
+                       .AddSingleton<IETagStore, TestETagStore>();
+    }
+
+    [SuppressMessage(category: "Microsoft.Performance", checkId: "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Instantiated by dependency injection")]
+    private sealed class TestETagStore : IETagStore
+    {
+        public ValueTask<string?> GetETagAsync(string key, CancellationToken cancellationToken)
+        {
+            return new((string?)null);
+        }
+
+        public ValueTask SaveETagAsync(string key, string eTag, CancellationToken cancellationToken)
+        {
+            return ValueTask.CompletedTask;
+        }
     }
 
     [Fact]

--- a/src/Credfeto.Dispatcher.GitHub.Tests/GitHubSetupTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/GitHubSetupTests.cs
@@ -4,6 +4,7 @@ using Credfeto.Dispatcher.GitHub.Services;
 using FunFair.Test.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 using Xunit;
 
 namespace Credfeto.Dispatcher.GitHub.Tests;
@@ -18,7 +19,8 @@ public sealed class GitHubSetupTests : DependencyInjectionTestsBase
     private static IServiceCollection Configure(IServiceCollection services)
     {
         return services.AddGitHub()
-                       .AddSingleton<IOptions<GitHubOptions>>(Options.Create(new GitHubOptions()));
+                       .AddSingleton<IOptions<GitHubOptions>>(Options.Create(new GitHubOptions()))
+                       .AddSingleton(Substitute.For<IETagStore>());
     }
 
     [Fact]

--- a/src/Credfeto.Dispatcher.GitHub.Tests/GitHubSetupTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/GitHubSetupTests.cs
@@ -1,12 +1,10 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Threading;
-using System.Threading.Tasks;
 using Credfeto.Dispatcher.GitHub.Configuration;
 using Credfeto.Dispatcher.GitHub.Interfaces;
 using Credfeto.Dispatcher.GitHub.Services;
 using FunFair.Test.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 using Xunit;
 
 namespace Credfeto.Dispatcher.GitHub.Tests;
@@ -21,22 +19,8 @@ public sealed class GitHubSetupTests : DependencyInjectionTestsBase
     private static IServiceCollection Configure(IServiceCollection services)
     {
         return services.AddGitHub()
-                       .AddSingleton<IOptions<GitHubOptions>>(Options.Create(new GitHubOptions()))
-                       .AddSingleton<IETagStore, TestETagStore>();
-    }
-
-    [SuppressMessage(category: "Microsoft.Performance", checkId: "CA1812:AvoidUninstantiatedInternalClasses", Justification = "Instantiated by dependency injection")]
-    private sealed class TestETagStore : IETagStore
-    {
-        public ValueTask<string?> GetETagAsync(string key, CancellationToken cancellationToken)
-        {
-            return new((string?)null);
-        }
-
-        public ValueTask SaveETagAsync(string key, string eTag, CancellationToken cancellationToken)
-        {
-            return ValueTask.CompletedTask;
-        }
+                       .AddMockedService<IOptions<GitHubOptions>>(static o => o.Value.Returns(new GitHubOptions()))
+                       .AddMockedService<IETagStore>();
     }
 
     [Fact]

--- a/src/Credfeto.Dispatcher.GitHub.Tests/Helpers/FixedResponseHandler.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/Helpers/FixedResponseHandler.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,13 +9,15 @@ namespace Credfeto.Dispatcher.GitHub.Tests.Helpers;
 
 internal sealed class FixedResponseHandler : HttpMessageHandler
 {
-    private readonly HttpStatusCode _statusCode;
     private readonly string? _content;
+    private readonly string? _eTag;
+    private readonly HttpStatusCode _statusCode;
 
-    public FixedResponseHandler(HttpStatusCode statusCode, string? content = null)
+    public FixedResponseHandler(HttpStatusCode statusCode, string? content = null, string? eTag = null)
     {
         this._statusCode = statusCode;
         this._content = content;
+        this._eTag = eTag;
     }
 
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -24,6 +27,11 @@ internal sealed class FixedResponseHandler : HttpMessageHandler
         if (this._content is not null)
         {
             response.Content = new StringContent(content: this._content, encoding: Encoding.UTF8, mediaType: "application/json");
+        }
+
+        if (this._eTag is not null)
+        {
+            response.Headers.ETag = new EntityTagHeaderValue(this._eTag);
         }
 
         return Task.FromResult(response);

--- a/src/Credfeto.Dispatcher.GitHub.Tests/Services/NotificationFilterTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/Services/NotificationFilterTests.cs
@@ -5,9 +5,7 @@ using Credfeto.Dispatcher.GitHub.Interfaces;
 using Credfeto.Dispatcher.GitHub.Services;
 using FunFair.Test.Common;
 using FunFair.Test.Common.Helpers;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using NSubstitute;
 using Xunit;
 
 namespace Credfeto.Dispatcher.GitHub.Tests.Services;
@@ -16,9 +14,9 @@ public sealed class NotificationFilterTests : TestBase
 {
     private static readonly NotificationSubject DefaultSubject = new(Title: "Test", Url: new Uri("https://api.github.com/repos/owner/repo/pulls/1"), Type: "PullRequest");
 
-    private static INotificationFilter BuildFilter(GitHubOptions options)
+    private INotificationFilter BuildFilter(GitHubOptions options)
     {
-        return new NotificationFilter(options: Options.Create(options), logger: Substitute.For<ILogger<NotificationFilter>>());
+        return new NotificationFilter(options: Options.Create(options), logger: this.GetTypedLogger<NotificationFilter>());
     }
 
     private static GitHubNotification BuildNotification(string reason = "mention", string repoFullName = "owner/repo")
@@ -38,7 +36,7 @@ public sealed class NotificationFilterTests : TestBase
     [Fact]
     public void ShouldDispatchReturnsTrueWhenNoFiltersConfigured()
     {
-        INotificationFilter filter = BuildFilter(new GitHubOptions());
+        INotificationFilter filter = this.BuildFilter(new GitHubOptions());
         GitHubNotification notification = BuildNotification();
 
         bool result = filter.ShouldDispatch(notification);
@@ -53,7 +51,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { Reasons = ["mention"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
         GitHubNotification notification = BuildNotification(reason: "mention");
 
         bool result = filter.ShouldDispatch(notification);
@@ -68,7 +66,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { Reasons = ["mention"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
         GitHubNotification notification = BuildNotification(reason: "subscribed");
 
         bool result = filter.ShouldDispatch(notification);
@@ -83,7 +81,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { Reasons = ["MENTION"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
         GitHubNotification notification = BuildNotification(reason: "mention");
 
         bool result = filter.ShouldDispatch(notification);
@@ -98,7 +96,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { AllowedOwners = ["owner"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
         GitHubNotification notification = BuildNotification(repoFullName: "owner/repo");
 
         bool result = filter.ShouldDispatch(notification);
@@ -113,7 +111,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { AllowedOwners = ["allowed-owner"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
         GitHubNotification notification = BuildNotification(repoFullName: "other-owner/repo");
 
         bool result = filter.ShouldDispatch(notification);
@@ -128,7 +126,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { AllowedOwners = ["OWNER"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
         GitHubNotification notification = BuildNotification(repoFullName: "owner/repo");
 
         bool result = filter.ShouldDispatch(notification);
@@ -143,7 +141,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { ExcludedRepos = ["owner/other-repo"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
         GitHubNotification notification = BuildNotification(repoFullName: "owner/repo");
 
         bool result = filter.ShouldDispatch(notification);
@@ -158,7 +156,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { ExcludedRepos = ["owner/repo"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
         GitHubNotification notification = BuildNotification(repoFullName: "owner/repo");
 
         bool result = filter.ShouldDispatch(notification);
@@ -173,7 +171,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { ExcludedRepos = ["OWNER/REPO"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
         GitHubNotification notification = BuildNotification(repoFullName: "owner/repo");
 
         bool result = filter.ShouldDispatch(notification);
@@ -188,7 +186,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { AllowedOwners = ["owner"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
 
         NotificationRepository repository = new(FullName: "owner", Url: new Uri("https://github.com/owner"));
         GitHubNotification notification = new(Id: "1", Reason: "mention", Subject: DefaultSubject, Repository: repository, UpdatedAt: TimeSources.Past.UtcNowAsOffset, Unread: true);
@@ -208,7 +206,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { Reasons = ["mention", "review_requested", "assign"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
         GitHubNotification notification = BuildNotification(reason: reason);
 
         bool result = filter.ShouldDispatch(notification);
@@ -219,7 +217,7 @@ public sealed class NotificationFilterTests : TestBase
     [Fact]
     public void ShouldDispatchReturnsTrueWhenAllowedReposIsEmpty()
     {
-        INotificationFilter filter = BuildFilter(new GitHubOptions());
+        INotificationFilter filter = this.BuildFilter(new GitHubOptions());
         GitHubNotification notification = BuildNotification(repoFullName: "owner/any-repo");
 
         bool result = filter.ShouldDispatch(notification);
@@ -234,7 +232,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { AllowedRepos = ["owner/repo"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
         GitHubNotification notification = BuildNotification(repoFullName: "owner/repo");
 
         bool result = filter.ShouldDispatch(notification);
@@ -249,7 +247,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { AllowedRepos = ["owner/repo"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
         GitHubNotification notification = BuildNotification(repoFullName: "owner/other-repo");
 
         bool result = filter.ShouldDispatch(notification);
@@ -264,7 +262,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { AllowedRepos = ["OWNER/REPO"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
         GitHubNotification notification = BuildNotification(repoFullName: "owner/repo");
 
         bool result = filter.ShouldDispatch(notification);
@@ -279,7 +277,7 @@ public sealed class NotificationFilterTests : TestBase
         {
             Filter = new GitHubFilterOptions { AllowedRepos = ["owner/repo-a", "owner/repo-b"] }
         };
-        INotificationFilter filter = BuildFilter(options);
+        INotificationFilter filter = this.BuildFilter(options);
         GitHubNotification notificationA = BuildNotification(repoFullName: "owner/repo-a");
         GitHubNotification notificationB = BuildNotification(repoFullName: "owner/repo-b");
         GitHubNotification notificationC = BuildNotification(repoFullName: "owner/repo-c");

--- a/src/Credfeto.Dispatcher.GitHub.Tests/Services/NotificationPollerTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/Services/NotificationPollerTests.cs
@@ -9,7 +9,6 @@ using Credfeto.Dispatcher.GitHub.Services;
 using Credfeto.Dispatcher.GitHub.Tests.Helpers;
 using FunFair.Test.Common;
 using FunFair.Test.Common.Extensions;
-using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 
@@ -44,9 +43,9 @@ public sealed class NotificationPollerTests : TestBase
 
     public NotificationPollerTests()
     {
-        this._httpClientFactory = Substitute.For<System.Net.Http.IHttpClientFactory>();
-        this._eTagStore = Substitute.For<IETagStore>();
-        this._poller = new NotificationPoller(httpClientFactory: this._httpClientFactory, eTagStore: this._eTagStore, logger: Substitute.For<ILogger<NotificationPoller>>());
+        this._httpClientFactory = GetSubstitute<System.Net.Http.IHttpClientFactory>();
+        this._eTagStore = GetSubstitute<IETagStore>();
+        this._poller = new NotificationPoller(httpClientFactory: this._httpClientFactory, eTagStore: this._eTagStore, logger: this.GetTypedLogger<NotificationPoller>());
     }
 
     [Fact]

--- a/src/Credfeto.Dispatcher.GitHub.Tests/Services/NotificationPollerTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/Services/NotificationPollerTests.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Credfeto.Dispatcher.GitHub.DataTypes;
 using Credfeto.Dispatcher.GitHub.Interfaces;
 using Credfeto.Dispatcher.GitHub.Services;
+using Credfeto.Dispatcher.GitHub.Tests.Helpers;
 using FunFair.Test.Common;
 using FunFair.Test.Common.Extensions;
 using Microsoft.Extensions.Logging;
@@ -36,13 +38,15 @@ public sealed class NotificationPollerTests : TestBase
         ]
         """;
 
+    private readonly IETagStore _eTagStore;
     private readonly System.Net.Http.IHttpClientFactory _httpClientFactory;
     private readonly INotificationPoller _poller;
 
     public NotificationPollerTests()
     {
         this._httpClientFactory = Substitute.For<System.Net.Http.IHttpClientFactory>();
-        this._poller = new NotificationPoller(httpClientFactory: this._httpClientFactory, logger: Substitute.For<ILogger<NotificationPoller>>());
+        this._eTagStore = Substitute.For<IETagStore>();
+        this._poller = new NotificationPoller(httpClientFactory: this._httpClientFactory, eTagStore: this._eTagStore, logger: Substitute.For<ILogger<NotificationPoller>>());
     }
 
     [Fact]
@@ -196,5 +200,50 @@ public sealed class NotificationPollerTests : TestBase
         IReadOnlyList<GitHubNotification> result = await this._poller.PollAsync(this.CancellationToken());
 
         Assert.Equal(expected: new Uri("about:blank"), actual: result[0].Subject.Url);
+    }
+
+    [Fact]
+    public async Task PollAsyncLoadsETagFromStoreOnFirstCallAsync()
+    {
+        this._httpClientFactory.MockCreateClientWithResponse(clientName: "GitHub", httpStatusCode: HttpStatusCode.OK, responseMessage: NotificationJson);
+
+        await this._poller.PollAsync(this.CancellationToken());
+
+        await this._eTagStore.Received(1)
+                  .GetETagAsync(key: "github.notifications", cancellationToken: this.CancellationToken());
+    }
+
+    [Fact]
+    public async Task PollAsyncSavesETagToStoreWhenResponseIncludesETagAsync()
+    {
+        const string eTagJson =
+            """
+            [
+              {
+                "id": "3",
+                "reason": "mention",
+                "subject": {
+                  "title": "A PR",
+                  "url": "https://api.github.com/repos/owner/repo/pulls/3",
+                  "type": "PullRequest"
+                },
+                "repository": {
+                  "full_name": "owner/repo",
+                  "html_url": "https://github.com/owner/repo"
+                },
+                "updated_at": "2024-01-01T00:00:00Z",
+                "unread": true
+              }
+            ]
+            """;
+
+        using FixedResponseHandler handler = new(statusCode: HttpStatusCode.OK, content: eTagJson, eTag: "\"new-etag\"");
+        using HttpClient httpClient = new(handler) { BaseAddress = new Uri("https://api.github.com/") };
+        this._httpClientFactory.CreateClient("GitHub").Returns(httpClient);
+
+        await this._poller.PollAsync(this.CancellationToken());
+
+        await this._eTagStore.Received(1)
+                  .SaveETagAsync(key: "github.notifications", eTag: "\"new-etag\"", cancellationToken: this.CancellationToken());
     }
 }

--- a/src/Credfeto.Dispatcher.GitHub.Tests/Services/PullRequestDetailFetcherTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/Services/PullRequestDetailFetcherTests.cs
@@ -142,7 +142,7 @@ public sealed class PullRequestDetailFetcherTests : TestBase
 
     public PullRequestDetailFetcherTests()
     {
-        this._httpClientFactory = Substitute.For<System.Net.Http.IHttpClientFactory>();
+        this._httpClientFactory = GetSubstitute<System.Net.Http.IHttpClientFactory>();
         this._fetcher = new PullRequestDetailFetcher(this._httpClientFactory);
     }
 

--- a/src/Credfeto.Dispatcher.GitHub/Services/NotificationPoller.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Services/NotificationPoller.cs
@@ -16,45 +16,49 @@ namespace Credfeto.Dispatcher.GitHub.Services;
 
 public sealed class NotificationPoller : INotificationPoller
 {
+    private const string ETagKey = "github.notifications";
     private static readonly Uri NotificationsRelativeUri = new(uriString: "notifications", uriKind: UriKind.Relative);
 
+    private readonly IETagStore _eTagStore;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<NotificationPoller> _logger;
-    private string? _eTag;
     private IReadOnlyList<GitHubNotification> _lastResult = [];
 
-    public NotificationPoller(IHttpClientFactory httpClientFactory, ILogger<NotificationPoller> logger)
+    public NotificationPoller(IHttpClientFactory httpClientFactory, IETagStore eTagStore, ILogger<NotificationPoller> logger)
     {
         this._httpClientFactory = httpClientFactory;
+        this._eTagStore = eTagStore;
         this._logger = logger;
     }
 
     public async ValueTask<IReadOnlyList<GitHubNotification>> PollAsync(CancellationToken cancellationToken)
     {
-        if (this._eTag is null)
+        string? eTag = await this._eTagStore.GetETagAsync(key: ETagKey, cancellationToken: cancellationToken);
+
+        if (eTag is null)
         {
             this._logger.LogPollingFirstCall();
         }
         else
         {
-            this._logger.LogPollingWithETag(eTag: this._eTag);
+            this._logger.LogPollingWithETag(eTag: eTag);
         }
 
         HttpClient httpClient = this._httpClientFactory.CreateClient("GitHub");
 
-        using HttpRequestMessage request = this.BuildRequest();
+        using HttpRequestMessage request = BuildRequest(eTag);
         using HttpResponseMessage response = await httpClient.SendAsync(request: request, cancellationToken: cancellationToken);
 
         return await this.ProcessResponseAsync(response: response, cancellationToken: cancellationToken);
     }
 
-    private HttpRequestMessage BuildRequest()
+    private static HttpRequestMessage BuildRequest(string? eTag)
     {
         HttpRequestMessage request = new(method: HttpMethod.Get, requestUri: NotificationsRelativeUri);
 
-        if (this._eTag is not null)
+        if (eTag is not null)
         {
-            request.Headers.IfNoneMatch.Add(new EntityTagHeaderValue(this._eTag));
+            request.Headers.IfNoneMatch.Add(new EntityTagHeaderValue(eTag));
         }
 
         return request;
@@ -73,7 +77,7 @@ public sealed class NotificationPoller : INotificationPoller
 
         if (response.Headers.ETag is not null)
         {
-            this._eTag = response.Headers.ETag.Tag;
+            await this._eTagStore.SaveETagAsync(key: ETagKey, eTag: response.Headers.ETag.Tag, cancellationToken: cancellationToken);
         }
 
         string json = await response.Content.ReadAsStringAsync(cancellationToken);

--- a/src/Credfeto.Dispatcher.Storage.Tests/Credfeto.Dispatcher.Storage.Tests.csproj
+++ b/src/Credfeto.Dispatcher.Storage.Tests/Credfeto.Dispatcher.Storage.Tests.csproj
@@ -7,7 +7,7 @@
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <Features>strict;flow-analysis</Features>
     <GenerateNeutralResourcesLanguageAttribute>true</GenerateNeutralResourcesLanguageAttribute>
@@ -16,20 +16,21 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
-    <IsTrimmable>false</IsTrimmable>
     <LangVersion>latest</LangVersion>
     <NoWarn />
     <NuGetAudit>true</NuGetAudit>
-    <NuGetAuditLevel>low</NuGetAuditLevel>
+    <NuGetAuditLevel>high</NuGetAuditLevel>
     <NuGetAuditMode>all</NuGetAuditMode>
     <Nullable>enable</Nullable>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
     <RunAOTCompilation>false</RunAOTCompilation>
     <TargetFramework>net10.0</TargetFramework>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <WarningsAsErrors />
@@ -42,21 +43,24 @@
     <!-- error NU1903: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability -->
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-xhfc-gr8f-ffwc" />
   </ItemGroup>
+  <Import Project="$(SolutionDir)UnitTests.props" Condition="Exists('$(SolutionDir)UnitTests.props')" />
   <ItemGroup>
-    <PackageReference Include="Credfeto.Services.Startup.Interfaces" Version="1.1.143.1554" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
+    <ProjectReference Include="..\Credfeto.Dispatcher.Storage\Credfeto.Dispatcher.Storage.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Credfeto.Dispatcher.GitHub.Interfaces\Credfeto.Dispatcher.GitHub.Interfaces.csproj" />
+    <PackageReference Include="FunFair.Test.Common" Version="6.2.19.2017" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="codecracker.CSharp" Version="1.1.0" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Credfeto.Enumeration.Source.Generation" Version="1.2.140.1751" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="FunFair.CodeAnalysis" Version="7.1.36.1750" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.19.2017" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Meziantou.Analyzer" Version="3.0.24" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Nullable.Extended.Analyzer" Version="1.15.6581" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer" Version="2.0.0" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers" Version="2.0.0" PrivateAssets="All" ExcludeAssets="runtime" />
@@ -66,5 +70,6 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.23.0.137933" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="ToStringWithoutOverrideAnalyzer" Version="0.6.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="xunit.analyzers" Version="1.27.0" PrivateAssets="All" ExcludeAssets="runtime" />
   </ItemGroup>
 </Project>

--- a/src/Credfeto.Dispatcher.Storage.Tests/Services/ETagStoreTests.cs
+++ b/src/Credfeto.Dispatcher.Storage.Tests/Services/ETagStoreTests.cs
@@ -1,0 +1,118 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.Dispatcher.GitHub.Interfaces;
+using Credfeto.Dispatcher.Storage.Services;
+using FunFair.Test.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Credfeto.Dispatcher.Storage.Tests.Services;
+
+public sealed class ETagStoreTests : TestBase, IAsyncLifetime
+{
+    private const string TestKey = "test.key";
+    private const string TestETag = "\"abc123\"";
+    private const string UpdatedETag = "\"xyz789\"";
+
+    private readonly IETagStore _store;
+    private readonly SqliteConnection _connection;
+
+    public ETagStoreTests()
+    {
+        this._connection = new SqliteConnection("DataSource=:memory:");
+        this._connection.Open();
+
+        DbContextOptions<DispatcherDbContext> options = new DbContextOptionsBuilder<DispatcherDbContext>()
+                                                        .UseSqlite(this._connection)
+                                                        .Options;
+
+        using (DispatcherDbContext ctx = new(options))
+        {
+            ctx.Database.EnsureCreated();
+        }
+
+        this._store = new ETagStore(new TestDbContextFactory(options));
+    }
+
+    public ValueTask InitializeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return this._connection.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetETagAsyncReturnsNullWhenNoRecordExistsAsync()
+    {
+        string? result = await this._store.GetETagAsync(key: TestKey, cancellationToken: this.CancellationToken());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetETagAsyncReturnsStoredValueAfterSaveAsync()
+    {
+        await this._store.SaveETagAsync(key: TestKey, eTag: TestETag, cancellationToken: this.CancellationToken());
+
+        string? result = await this._store.GetETagAsync(key: TestKey, cancellationToken: this.CancellationToken());
+
+        Assert.Equal(expected: TestETag, actual: result);
+    }
+
+    [Fact]
+    public async Task SaveETagAsyncCreatesNewRecordWhenNoneExistsAsync()
+    {
+        await this._store.SaveETagAsync(key: TestKey, eTag: TestETag, cancellationToken: this.CancellationToken());
+
+        string? result = await this._store.GetETagAsync(key: TestKey, cancellationToken: this.CancellationToken());
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task SaveETagAsyncUpdatesExistingRecordAsync()
+    {
+        await this._store.SaveETagAsync(key: TestKey, eTag: TestETag, cancellationToken: this.CancellationToken());
+        await this._store.SaveETagAsync(key: TestKey, eTag: UpdatedETag, cancellationToken: this.CancellationToken());
+
+        string? result = await this._store.GetETagAsync(key: TestKey, cancellationToken: this.CancellationToken());
+
+        Assert.Equal(expected: UpdatedETag, actual: result);
+    }
+
+    [Fact]
+    public async Task SaveETagAsyncDoesNotAffectOtherKeysAsync()
+    {
+        const string otherKey = "other.key";
+
+        await this._store.SaveETagAsync(key: TestKey, eTag: TestETag, cancellationToken: this.CancellationToken());
+
+        string? result = await this._store.GetETagAsync(key: otherKey, cancellationToken: this.CancellationToken());
+
+        Assert.Null(result);
+    }
+
+    private sealed class TestDbContextFactory : IDbContextFactory<DispatcherDbContext>
+    {
+        private readonly DbContextOptions<DispatcherDbContext> _options;
+
+        public TestDbContextFactory(DbContextOptions<DispatcherDbContext> options)
+        {
+            this._options = options;
+        }
+
+        public DispatcherDbContext CreateDbContext()
+        {
+            return new DispatcherDbContext(this._options);
+        }
+
+        public Task<DispatcherDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new DispatcherDbContext(this._options));
+        }
+    }
+}

--- a/src/Credfeto.Dispatcher.Storage/DispatcherDbContext.cs
+++ b/src/Credfeto.Dispatcher.Storage/DispatcherDbContext.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using Credfeto.Dispatcher.Storage.Entities;
 using Microsoft.EntityFrameworkCore;
 
 namespace Credfeto.Dispatcher.Storage;
@@ -9,4 +11,6 @@ public sealed class DispatcherDbContext : DbContext
     {
     }
 
+    [SuppressMessage(category: "Nullable.Extended.Analyzer", checkId: "NX0004:NullForgivingOperator", Justification = "Populated by Entity Framework Core")]
+    public DbSet<PollingStateEntity> PollingStates { get; init; } = default!;
 }

--- a/src/Credfeto.Dispatcher.Storage/Entities/PollingStateEntity.cs
+++ b/src/Credfeto.Dispatcher.Storage/Entities/PollingStateEntity.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+
+namespace Credfeto.Dispatcher.Storage.Entities;
+
+[DebuggerDisplay("{Key}: {ETag}")]
+public sealed class PollingStateEntity
+{
+    [Key]
+    [MaxLength(256)]
+    public required string Key { get; init; }
+
+    [MaxLength(1024)]
+    public required string ETag { get; init; }
+}

--- a/src/Credfeto.Dispatcher.Storage/Migrations/AddPollingStateTable.cs
+++ b/src/Credfeto.Dispatcher.Storage/Migrations/AddPollingStateTable.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Credfeto.Dispatcher.Storage.Migrations;
+
+[Migration("20260423120000_AddPollingStateTable")]
+public sealed partial class AddPollingStateTable : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "PollingStates",
+            columns: table => new
+            {
+                Key = table.Column<string>(type: "TEXT", maxLength: 256, nullable: false),
+                ETag = table.Column<string>(type: "TEXT", maxLength: 1024, nullable: false)
+            },
+            constraints: table => table.PrimaryKey("PK_PollingStates", x => x.Key)
+        );
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "PollingStates");
+    }
+}

--- a/src/Credfeto.Dispatcher.Storage/Migrations/DispatcherDbContextModelSnapshot.cs
+++ b/src/Credfeto.Dispatcher.Storage/Migrations/DispatcherDbContextModelSnapshot.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Credfeto.Dispatcher.Storage.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
@@ -11,5 +12,20 @@ internal sealed class DispatcherDbContextModelSnapshot : ModelSnapshot
     protected override void BuildModel(ModelBuilder modelBuilder)
     {
         modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
+
+        modelBuilder.Entity<PollingStateEntity>(
+            b =>
+            {
+                b.Property<string>("Key")
+                 .HasMaxLength(256)
+                 .HasColumnType("TEXT");
+                b.Property<string>("ETag")
+                 .IsRequired()
+                 .HasMaxLength(1024)
+                 .HasColumnType("TEXT");
+                b.HasKey("Key");
+                b.ToTable("PollingStates");
+            }
+        );
     }
 }

--- a/src/Credfeto.Dispatcher.Storage/Services/ETagStore.cs
+++ b/src/Credfeto.Dispatcher.Storage/Services/ETagStore.cs
@@ -1,0 +1,44 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.Dispatcher.GitHub.Interfaces;
+using Credfeto.Dispatcher.Storage.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Credfeto.Dispatcher.Storage.Services;
+
+public sealed class ETagStore : IETagStore
+{
+    private readonly IDbContextFactory<DispatcherDbContext> _dbContextFactory;
+
+    public ETagStore(IDbContextFactory<DispatcherDbContext> dbContextFactory)
+    {
+        this._dbContextFactory = dbContextFactory;
+    }
+
+    public async ValueTask<string?> GetETagAsync(string key, CancellationToken cancellationToken)
+    {
+        await using DispatcherDbContext context = await this._dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        PollingStateEntity? entity = await context.PollingStates.FindAsync(keyValues: [key], cancellationToken: cancellationToken);
+
+        return entity?.ETag;
+    }
+
+    public async ValueTask SaveETagAsync(string key, string eTag, CancellationToken cancellationToken)
+    {
+        await using DispatcherDbContext context = await this._dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        PollingStateEntity? existing = await context.PollingStates.FindAsync(keyValues: [key], cancellationToken: cancellationToken);
+
+        if (existing is null)
+        {
+            context.PollingStates.Add(new PollingStateEntity { Key = key, ETag = eTag });
+        }
+        else
+        {
+            context.PollingStates.Entry(existing).CurrentValues.SetValues(new PollingStateEntity { Key = key, ETag = eTag });
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Credfeto.Dispatcher.Storage/StorageSetup.cs
+++ b/src/Credfeto.Dispatcher.Storage/StorageSetup.cs
@@ -1,5 +1,6 @@
-using System;
 using System.IO;
+using Credfeto.Dispatcher.GitHub.Interfaces;
+using Credfeto.Dispatcher.Storage.Services;
 using Credfeto.Services.Startup.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,6 +22,7 @@ public static class StorageSetup
 
         return services
             .AddDbContextFactory<DispatcherDbContext>(options => options.UseSqlite($"Data Source={dbPath}"))
-            .AddRunOnStartupTask<DatabaseMigrationService>();
+            .AddRunOnStartupTask<DatabaseMigrationService>()
+            .AddSingleton<IETagStore, ETagStore>();
     }
 }

--- a/src/Credfeto.Dispatcher.slnx
+++ b/src/Credfeto.Dispatcher.slnx
@@ -15,6 +15,7 @@
   </Folder>
   <Folder Name="/Storage/">
     <Project Path="Credfeto.Dispatcher.Storage/Credfeto.Dispatcher.Storage.csproj" />
+    <Project Path="Credfeto.Dispatcher.Storage.Tests/Credfeto.Dispatcher.Storage.Tests.csproj" />
   </Folder>
   <Folder Name="/Services/GitHub/">
     <Project Path="Credfeto.Dispatcher.GitHub.DataTypes/Credfeto.Dispatcher.GitHub.DataTypes.csproj" />

--- a/src/Credfeto.Dispatcher.slnx
+++ b/src/Credfeto.Dispatcher.slnx
@@ -4,7 +4,9 @@
     <File Path="../Dockerfile" />
     <File Path="../README.md" />
     <File Path="../healthcheck" />
-    <File Path="CodeAnalysis.ruleset" />
+    <File Path="..\.ai-instructions" />
+    <File Path="..\.editorconfig" />
+    <File Path="..\.globalconfig" />
     <File Path="global.json" />
     <File Path="publish" />
   </Folder>


### PR DESCRIPTION
## Summary

Implements #21

Persists the GitHub notifications API ETag in the SQLite database so polling can resume from where it left off after a service restart, reducing unnecessary API calls and respecting HTTP conditional request semantics.

## Changes

- **** — new interface in  with  / 
- **** — EF Core entity ( PK, ) with migration 
- **** — implementation in  using 
- **** — DI registration of 
- **** — loads ETag from store before each poll, saves new ETag when response includes one
- **** — new test project with 5 tests covering all  behaviour
- **** — updated with  mock and two new tests

## Test results

All 84 tests pass.