### PR TITLE
fix: Add [DbContext] attribute to migrations so EF Core can discover them at runtime

### DIFF
--- a/src/Credfeto.Dispatcher.Storage.Tests/Services/ETagStoreTests.cs
+++ b/src/Credfeto.Dispatcher.Storage.Tests/Services/ETagStoreTests.cs
@@ -29,7 +29,7 @@ public sealed class ETagStoreTests : TestBase, IAsyncLifetime
 
         using (DispatcherDbContext ctx = new(options))
         {
-            ctx.Database.EnsureCreated();
+            ctx.Database.Migrate();
         }
 
         this._store = new ETagStore(new TestDbContextFactory(options));

--- a/src/Credfeto.Dispatcher.Storage/Migrations/AddPollingStateTable.cs
+++ b/src/Credfeto.Dispatcher.Storage/Migrations/AddPollingStateTable.cs
@@ -1,7 +1,10 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Credfeto.Dispatcher.Storage.Migrations;
 
+[DbContext(typeof(DispatcherDbContext))]
 [Migration("20260423120000_AddPollingStateTable")]
 public sealed partial class AddPollingStateTable : Migration
 {

--- a/src/Credfeto.Dispatcher.Storage/Migrations/InitialCreate.cs
+++ b/src/Credfeto.Dispatcher.Storage/Migrations/InitialCreate.cs
@@ -1,7 +1,10 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Credfeto.Dispatcher.Storage.Migrations;
 
+[DbContext(typeof(DispatcherDbContext))]
 [Migration("20260423000000_InitialCreate")]
 public sealed partial class InitialCreate : Migration
 {


### PR DESCRIPTION
## Problem

All hand-written EF Core migrations were missing `[DbContext(typeof(DispatcherDbContext))]`. EF Core's `IMigrationsAssembly` uses this attribute to filter which migration classes belong to a given DbContext. Without it, `MigrateAsync()` silently finds zero pending migrations and never creates the tables — causing `No such table: PollingStates` at runtime.

## Changes

- Add `[DbContext(typeof(DispatcherDbContext))]` to `InitialCreate` and `AddPollingStateTable` migrations
- Change `ETagStoreTests` from `EnsureCreated()` to `Migrate()` so tests actually validate migration execution (`EnsureCreated` bypasses migrations entirely and would hide this class of bug)

The same fix is also applied to PR #26 (`copilot/update-notification-handling`) which adds the `AddPullRequestAndIssueTables` migration.