### PR TITLE
fix: prevent repeated notifications for closed PRs/Issues

### DIFF
--- a/src/Credfeto.Dispatcher.Storage.Tests/NotificationStateTrackerTests.cs
+++ b/src/Credfeto.Dispatcher.Storage.Tests/NotificationStateTrackerTests.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.Date.Interfaces;
+using Credfeto.Dispatcher.Storage;
+using Credfeto.Dispatcher.Storage.Entities;
+using FunFair.Test.Common;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Credfeto.Dispatcher.Storage.Tests;
+
+public sealed class NotificationStateTrackerTests : TestBase
+{
+    private readonly ICurrentTimeSource _currentTimeSource;
+    private readonly IDbContextFactory<DispatcherDbContext> _dbContextFactory;
+    private readonly NotificationStateTracker _tracker;
+
+    public NotificationStateTrackerTests()
+    {
+        this._currentTimeSource = GetSubstitute<ICurrentTimeSource>();
+        this._currentTimeSource.UtcNow.Returns(DateTimeOffset.UtcNow);
+
+        var options = new DbContextOptionsBuilder<DispatcherDbContext>()
+            .UseInMemoryDatabase(databaseName: $"test-db-{Guid.NewGuid()}")
+            .Options;
+
+        this._dbContextFactory = new FakeDbContextFactory(options);
+        this._tracker = new NotificationStateTracker(dbContextFactory: this._dbContextFactory, currentTimeSource: this._currentTimeSource);
+    }
+
+    [Fact]
+    public async Task ShouldSkipPullRequestAsync_ReturnsFalse_WhenCurrentStatusIsNotClosedAsync()
+    {
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        bool result = await this._tracker.ShouldSkipPullRequestAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            currentStatus: "Open",
+            cancellationToken: token);
+
+        Assert.False(result, "Should not skip open PRs");
+    }
+
+    [Fact]
+    public async Task ShouldSkipPullRequestAsync_ReturnsFalse_WhenCurrentStatusIsClosedButNotInDatabaseAsync()
+    {
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        bool result = await this._tracker.ShouldSkipPullRequestAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            currentStatus: "Closed",
+            cancellationToken: token);
+
+        Assert.False(result, "Should not skip first-time closed PRs");
+    }
+
+    [Fact]
+    public async Task ShouldSkipPullRequestAsync_ReturnsTrue_WhenCurrentAndStoredStatusBothClosedAndMatchAsync()
+    {
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        await this._tracker.UpdatePullRequestStateAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            status: "Closed",
+            cancellationToken: token);
+
+        bool result = await this._tracker.ShouldSkipPullRequestAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            currentStatus: "Closed",
+            cancellationToken: token);
+
+        Assert.True(result, "Should skip repeated closed PRs");
+    }
+
+    [Fact]
+    public async Task ShouldSkipPullRequestAsync_ReturnsFalse_WhenStoredStatusDoesNotMatchCurrentStatusAsync()
+    {
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        await this._tracker.UpdatePullRequestStateAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            status: "Open",
+            cancellationToken: token);
+
+        bool result = await this._tracker.ShouldSkipPullRequestAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            currentStatus: "Closed",
+            cancellationToken: token);
+
+        Assert.False(result, "Should not skip when status changes from Open to Closed");
+    }
+
+    [Fact]
+    public async Task ShouldSkipPullRequestAsync_ReturnsFalse_WhenCaseDoesNotMatchAsync()
+    {
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        await this._tracker.UpdatePullRequestStateAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            status: "closed",
+            cancellationToken: token);
+
+        bool result = await this._tracker.ShouldSkipPullRequestAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            currentStatus: "CLOSED",
+            cancellationToken: token);
+
+        Assert.True(result, "Should use case-insensitive comparison for status");
+    }
+
+    [Fact]
+    public async Task ShouldSkipIssueAsync_ReturnsFalse_WhenCurrentStatusIsNotClosedAsync()
+    {
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        bool result = await this._tracker.ShouldSkipIssueAsync(
+            repository: "owner/repo",
+            issueNumber: 1,
+            currentStatus: "Open",
+            cancellationToken: token);
+
+        Assert.False(result, "Should not skip open issues");
+    }
+
+    [Fact]
+    public async Task ShouldSkipIssueAsync_ReturnsFalse_WhenCurrentStatusIsClosedButNotInDatabaseAsync()
+    {
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        bool result = await this._tracker.ShouldSkipIssueAsync(
+            repository: "owner/repo",
+            issueNumber: 1,
+            currentStatus: "Closed",
+            cancellationToken: token);
+
+        Assert.False(result, "Should not skip first-time closed issues");
+    }
+
+    [Fact]
+    public async Task ShouldSkipIssueAsync_ReturnsTrue_WhenCurrentAndStoredStatusBothClosedAndMatchAsync()
+    {
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        await this._tracker.UpdateIssueStateAsync(
+            repository: "owner/repo",
+            issueNumber: 1,
+            status: "Closed",
+            cancellationToken: token);
+
+        bool result = await this._tracker.ShouldSkipIssueAsync(
+            repository: "owner/repo",
+            issueNumber: 1,
+            currentStatus: "Closed",
+            cancellationToken: token);
+
+        Assert.True(result, "Should skip repeated closed issues");
+    }
+
+    [Fact]
+    public async Task ShouldSkipIssueAsync_ReturnsFalse_WhenStoredStatusDoesNotMatchCurrentStatusAsync()
+    {
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        await this._tracker.UpdateIssueStateAsync(
+            repository: "owner/repo",
+            issueNumber: 1,
+            status: "Open",
+            cancellationToken: token);
+
+        bool result = await this._tracker.ShouldSkipIssueAsync(
+            repository: "owner/repo",
+            issueNumber: 1,
+            currentStatus: "Closed",
+            cancellationToken: token);
+
+        Assert.False(result, "Should not skip when status changes from Open to Closed");
+    }
+
+    [Fact]
+    public async Task UpdatePullRequestStateAsync_CreatesNewRecord_WhenNotExistingAsync()
+    {
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        await this._tracker.UpdatePullRequestStateAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            status: "Closed",
+            cancellationToken: token);
+
+        bool result = await this._tracker.ShouldSkipPullRequestAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            currentStatus: "Closed",
+            cancellationToken: token);
+
+        Assert.True(result, "Record should be created and subsequent skip should return true");
+    }
+
+    [Fact]
+    public async Task UpdatePullRequestStateAsync_UpdatesExistingRecord_WhenChangingStatusAsync()
+    {
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        await this._tracker.UpdatePullRequestStateAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            status: "Open",
+            cancellationToken: token);
+
+        await this._tracker.UpdatePullRequestStateAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            status: "Closed",
+            cancellationToken: token);
+
+        bool result = await this._tracker.ShouldSkipPullRequestAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            currentStatus: "Closed",
+            cancellationToken: token);
+
+        Assert.True(result, "Updated record should be tracked correctly");
+    }
+
+    [Fact]
+    public async Task UpdatePullRequestStateAsync_ClearsWhenClosedOnReopen_WhenStatusChangesFromClosedToOpenAsync()
+    {
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        await this._tracker.UpdatePullRequestStateAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            status: "Closed",
+            cancellationToken: token);
+
+        await this._tracker.UpdatePullRequestStateAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            status: "Open",
+            cancellationToken: token);
+
+        bool result = await this._tracker.ShouldSkipPullRequestAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 1,
+            currentStatus: "Open",
+            cancellationToken: token);
+
+        Assert.False(result, "Reopened PRs should not be skipped");
+    }
+
+    [Fact]
+    public async Task ScenarioTestPullRequestLifecycle_FirstClosed_ThenOpen_ThenClosedAgainAsync()
+    {
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        // First closure notification
+        bool shouldSkip1 = await this._tracker.ShouldSkipPullRequestAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 42,
+            currentStatus: "Closed",
+            cancellationToken: token);
+        Assert.False(shouldSkip1, "First closure should be dispatched");
+
+        await this._tracker.UpdatePullRequestStateAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 42,
+            status: "Closed",
+            cancellationToken: token);
+
+        // Second closure notification (duplicate)
+        bool shouldSkip2 = await this._tracker.ShouldSkipPullRequestAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 42,
+            currentStatus: "Closed",
+            cancellationToken: token);
+        Assert.True(shouldSkip2, "Duplicate closure should be skipped");
+
+        // Reopen notification
+        bool shouldSkip3 = await this._tracker.ShouldSkipPullRequestAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 42,
+            currentStatus: "Open",
+            cancellationToken: token);
+        Assert.False(shouldSkip3, "Reopen should be dispatched");
+
+        await this._tracker.UpdatePullRequestStateAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 42,
+            status: "Open",
+            cancellationToken: token);
+
+        // Close again notification
+        bool shouldSkip4 = await this._tracker.ShouldSkipPullRequestAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 42,
+            currentStatus: "Closed",
+            cancellationToken: token);
+        Assert.False(shouldSkip4, "Second closure should be dispatched");
+
+        await this._tracker.UpdatePullRequestStateAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 42,
+            status: "Closed",
+            cancellationToken: token);
+
+        // Third closure notification (duplicate)
+        bool shouldSkip5 = await this._tracker.ShouldSkipPullRequestAsync(
+            repository: "owner/repo",
+            pullRequestNumber: 42,
+            currentStatus: "Closed",
+            cancellationToken: token);
+        Assert.True(shouldSkip5, "Duplicate second closure should be skipped");
+    }
+
+    private sealed class FakeDbContextFactory : IDbContextFactory<DispatcherDbContext>
+    {
+        private readonly DbContextOptions<DispatcherDbContext> _options;
+
+        public FakeDbContextFactory(DbContextOptions<DispatcherDbContext> options)
+        {
+            this._options = options;
+        }
+
+        public DispatcherDbContext CreateDbContext()
+        {
+            return new DispatcherDbContext(this._options);
+        }
+    }
+}

--- a/src/Credfeto.Dispatcher.Storage/NotificationStateTracker.cs
+++ b/src/Credfeto.Dispatcher.Storage/NotificationStateTracker.cs
@@ -32,7 +32,9 @@ public sealed class NotificationStateTracker : INotificationStateTracker
         await using DispatcherDbContext context = await this._dbContextFactory.CreateDbContextAsync(cancellationToken);
         PullRequestEntity? existing = await context.PullRequests.FindAsync(keyValues: [repository, pullRequestNumber], cancellationToken: cancellationToken);
 
-        return existing is not null && IsClosedStatus(existing.Status);
+        return existing is not null &&
+               string.Equals(existing.Status, currentStatus, StringComparison.OrdinalIgnoreCase) &&
+               IsClosedStatus(existing.Status);
     }
 
     [SuppressMessage("Philips.CodeAnalysis.DuplicateCodeAnalyzer", "PH2071:Duplicate shape found", Justification = "Structurally identical but operating on different entity types (PullRequestEntity vs IssueEntity).")]
@@ -64,7 +66,9 @@ public sealed class NotificationStateTracker : INotificationStateTracker
         await using DispatcherDbContext context = await this._dbContextFactory.CreateDbContextAsync(cancellationToken);
         IssueEntity? existing = await context.Issues.FindAsync(keyValues: [repository, issueNumber], cancellationToken: cancellationToken);
 
-        return existing is not null && IsClosedStatus(existing.Status);
+        return existing is not null &&
+               string.Equals(existing.Status, currentStatus, StringComparison.OrdinalIgnoreCase) &&
+               IsClosedStatus(existing.Status);
     }
 
     [SuppressMessage("Philips.CodeAnalysis.DuplicateCodeAnalyzer", "PH2071:Duplicate shape found", Justification = "Structurally identical but operating on different entity types (PullRequestEntity vs IssueEntity).")]


### PR DESCRIPTION
## Problem
Duplicate notifications were being sent for closed PRs and Issues repeatedly, despite the notification suppression feature being implemented in PR #26.

## Root Cause
The `NotificationStateTracker.ShouldSkipPullRequestAsync()` and `ShouldSkipIssueAsync()` methods only checked if a database record existed and was marked as closed, but didn't verify that the current status matched the recorded status. This could cause repeated notifications if there was any status tracking inconsistency.

**Original logic:**
```csharp
return existing is not null && IsClosedStatus(existing.Status);
```

## Solution
Updated both methods to verify the current status matches the recorded status (case-insensitively) before skipping notifications:

```csharp
return existing is not null &&
       string.Equals(existing.Status, currentStatus, StringComparison.OrdinalIgnoreCase) &&
       IsClosedStatus(existing.Status);
```

This ensures we only skip notifications when:
1. A record exists in the database
2. The recorded status matches the current status (case-insensitively)
3. That status is "Closed"

## Tests
Added `NotificationStateTrackerTests.cs` with comprehensive test coverage:
- ✅ First-time closed notifications are sent
- ✅ Duplicate closed notifications are skipped  
- ✅ Status changes (Open→Closed, Closed→Open) trigger notifications
- ✅ Case-insensitive status comparison works correctly
- ✅ Full PR/Issue lifecycle scenarios (Closed → Open → Closed)

Fixes #28