### PR TITLE
fix: store DateTimeOffset columns as INTEGER ticks (fixes #42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Track notification state (open/closed) for pull requests and issues in database to suppress repeated Discord notifications for already-closed items (#26)
 - Rich issue notification embeds in Discord with Status, Reason, Assignees, Labels, and Linked PR fields; `IssueDetails` enriched with `Assignees`, `Labels`, and `LinkedPullRequestUrl` populated from the GitHub Issues API (#16)
 ### Fixed
+- EF Core SQLite cannot translate DateTimeOffset <= comparisons when stored as TEXT; store DispatchAfter, QueuedAt, and UpdatedAt as long (UtcTicks) with INTEGER column type
 - Removed unused `Mediator` runtime package reference from `Credfeto.Dispatcher.Server` — `Mediator.SourceGenerator` source generator is sufficient; no separate runtime package is needed for a simple background service
 - Updated gitleaks configuration to suppress false positive secret detection caused by logging extension class name matching the GitHub token regex pattern
 ### Changed

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/GitHubPollingWorker.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/GitHubPollingWorker.cs
@@ -146,6 +146,7 @@ public sealed class GitHubPollingWorker : BackgroundService
         await this._discordDispatcher.SendAsync(message: fallbackMessage, cancellationToken: cancellationToken);
     }
 
+    [SuppressMessage("Philips.CodeAnalysis.DuplicateCodeAnalyzer", "PH2071:Duplicate shape found", Justification = "Structurally identical to TryProcessIssueNotificationAsync but operates on pull requests.")]
     private async ValueTask<bool> TryProcessPullRequestNotificationAsync(GitHubNotification notification, CancellationToken cancellationToken)
     {
         PullRequestDetails? details = await this._pullRequestDetailFetcher.FetchAsync(notification: notification, cancellationToken: cancellationToken);

--- a/src/Credfeto.Dispatcher.Storage/DispatcherDbContext.cs
+++ b/src/Credfeto.Dispatcher.Storage/DispatcherDbContext.cs
@@ -41,6 +41,21 @@ public sealed class DispatcherDbContext : DbContext
                     .HasConversion(v => v.AbsoluteUri, v => new Uri(v, UriKind.Absolute));
 
         modelBuilder.Entity<NotificationQueueEntity>()
+                    .Property(e => e.DispatchAfter)
+                    .HasConversion(v => v.UtcTicks, v => new DateTimeOffset(v, TimeSpan.Zero))
+                    .HasColumnType("INTEGER");
+
+        modelBuilder.Entity<NotificationQueueEntity>()
+                    .Property(e => e.QueuedAt)
+                    .HasConversion(v => v.UtcTicks, v => new DateTimeOffset(v, TimeSpan.Zero))
+                    .HasColumnType("INTEGER");
+
+        modelBuilder.Entity<NotificationQueueEntity>()
+                    .Property(e => e.UpdatedAt)
+                    .HasConversion(v => v.UtcTicks, v => new DateTimeOffset(v, TimeSpan.Zero))
+                    .HasColumnType("INTEGER");
+
+        modelBuilder.Entity<NotificationQueueEntity>()
                     .HasIndex(e => e.DispatchAfter);
     }
 }

--- a/src/Credfeto.Dispatcher.Storage/Migrations/ChangeNotificationQueueDateTimeColumnsToInteger.cs
+++ b/src/Credfeto.Dispatcher.Storage/Migrations/ChangeNotificationQueueDateTimeColumnsToInteger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -7,6 +8,7 @@ namespace Credfeto.Dispatcher.Storage.Migrations;
 
 [DbContext(typeof(DispatcherDbContext))]
 [Migration("20260425000000_ChangeNotificationQueueDateTimeColumnsToInteger")]
+[SuppressMessage("Philips.CodeAnalysis.DuplicateCodeAnalyzer", "PH2071:Duplicate shape found", Justification = "Migration Up/Down methods necessarily mirror each other; Up creates with INTEGER columns, Down recreates with TEXT columns.")]
 public sealed partial class ChangeNotificationQueueDateTimeColumnsToInteger : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder)

--- a/src/Credfeto.Dispatcher.Storage/Migrations/ChangeNotificationQueueDateTimeColumnsToInteger.cs
+++ b/src/Credfeto.Dispatcher.Storage/Migrations/ChangeNotificationQueueDateTimeColumnsToInteger.cs
@@ -1,0 +1,79 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Credfeto.Dispatcher.Storage.Migrations;
+
+[DbContext(typeof(DispatcherDbContext))]
+[Migration("20260425000000_ChangeNotificationQueueDateTimeColumnsToInteger")]
+public sealed partial class ChangeNotificationQueueDateTimeColumnsToInteger : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_NotificationQueue_DispatchAfter",
+            table: "NotificationQueue");
+
+        migrationBuilder.DropTable(name: "NotificationQueue");
+
+        migrationBuilder.CreateTable(
+            name: "NotificationQueue",
+            columns: table => new
+            {
+                SubjectUrl = table.Column<string>(type: "TEXT", nullable: false),
+                NotificationId = table.Column<string>(type: "TEXT", nullable: false),
+                Repository = table.Column<string>(type: "TEXT", nullable: false),
+                RepositoryUrl = table.Column<string>(type: "TEXT", nullable: false),
+                SubjectType = table.Column<string>(type: "TEXT", nullable: false),
+                SubjectTitle = table.Column<string>(type: "TEXT", nullable: false),
+                Reason = table.Column<string>(type: "TEXT", nullable: false),
+                UpdatedAt = table.Column<long>(type: "INTEGER", nullable: false),
+                QueuedAt = table.Column<long>(type: "INTEGER", nullable: false),
+                DispatchAfter = table.Column<long>(type: "INTEGER", nullable: false),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_NotificationQueue", x => x.SubjectUrl);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_NotificationQueue_DispatchAfter",
+            table: "NotificationQueue",
+            column: "DispatchAfter");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_NotificationQueue_DispatchAfter",
+            table: "NotificationQueue");
+
+        migrationBuilder.DropTable(name: "NotificationQueue");
+
+        migrationBuilder.CreateTable(
+            name: "NotificationQueue",
+            columns: table => new
+            {
+                SubjectUrl = table.Column<string>(type: "TEXT", nullable: false),
+                NotificationId = table.Column<string>(type: "TEXT", nullable: false),
+                Repository = table.Column<string>(type: "TEXT", nullable: false),
+                RepositoryUrl = table.Column<string>(type: "TEXT", nullable: false),
+                SubjectType = table.Column<string>(type: "TEXT", nullable: false),
+                SubjectTitle = table.Column<string>(type: "TEXT", nullable: false),
+                Reason = table.Column<string>(type: "TEXT", nullable: false),
+                UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                QueuedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                DispatchAfter = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_NotificationQueue", x => x.SubjectUrl);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_NotificationQueue_DispatchAfter",
+            table: "NotificationQueue",
+            column: "DispatchAfter");
+    }
+}

--- a/src/Credfeto.Dispatcher.Storage/Migrations/DispatcherDbContextModelSnapshot.cs
+++ b/src/Credfeto.Dispatcher.Storage/Migrations/DispatcherDbContextModelSnapshot.cs
@@ -77,9 +77,15 @@ internal sealed class DispatcherDbContextModelSnapshot : ModelSnapshot
             b.Property(e => e.SubjectType).IsRequired().HasColumnType("TEXT");
             b.Property(e => e.SubjectTitle).IsRequired().HasColumnType("TEXT");
             b.Property(e => e.Reason).IsRequired().HasColumnType("TEXT");
-            b.Property(e => e.UpdatedAt).HasColumnType("TEXT");
-            b.Property(e => e.QueuedAt).HasColumnType("TEXT");
-            b.Property(e => e.DispatchAfter).HasColumnType("TEXT");
+            b.Property(e => e.UpdatedAt)
+             .HasColumnType("INTEGER")
+             .HasConversion(new ValueConverter<DateTimeOffset, long>(v => v.UtcTicks, v => new DateTimeOffset(v, TimeSpan.Zero)));
+            b.Property(e => e.QueuedAt)
+             .HasColumnType("INTEGER")
+             .HasConversion(new ValueConverter<DateTimeOffset, long>(v => v.UtcTicks, v => new DateTimeOffset(v, TimeSpan.Zero)));
+            b.Property(e => e.DispatchAfter)
+             .HasColumnType("INTEGER")
+             .HasConversion(new ValueConverter<DateTimeOffset, long>(v => v.UtcTicks, v => new DateTimeOffset(v, TimeSpan.Zero)));
         });
     }
 }


### PR DESCRIPTION
## Problem

`PendingNotificationStore.GetReadyItemsAsync` throws `InvalidOperationException` at runtime:

> The LINQ expression `DbSet<NotificationQueueEntity>().Where(n => n.DispatchAfter <= @now)` could not be translated.

EF Core's SQLite provider cannot translate a `DateTimeOffset <= parameter` comparison when the column is stored as `TEXT`.

## Fix

Add value converters on `DispatchAfter`, `QueuedAt`, and `UpdatedAt` to store them as `long` (UTC ticks) with `HasColumnType("INTEGER")`. Integer comparisons translate cleanly to SQL, so the `Where` clause works.

Add a migration (`ChangeNotificationQueueDateTimeColumnsToInteger`) that drops and recreates the `NotificationQueue` table with `INTEGER` columns. Data loss on upgrade is acceptable — the queue table is new and has not shipped to production.

Update `DispatcherDbContextModelSnapshot` to reflect the new column types and converters.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)