### PR TITLE
fix(github): log warning when work item scanner has no repos configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 - Work item scanner background service that polls configured GitHub repositories for open pull requests and issues, updating notification state with priority, hold status, and linked PR information
 ### Fixed
+- Warning log when work item scanner starts with no repos configured, making misconfiguration visible in logs
 ### Changed
 - Dependencies - Updated Credfeto.Version.Information.Generator to 1.0.124.1183
 - Dependencies - Updated FunFair.CodeAnalysis to 7.1.41.1934

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/LoggingExtensions/WorkItemScannerServiceLoggingExtensions.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/LoggingExtensions/WorkItemScannerServiceLoggingExtensions.cs
@@ -13,6 +13,13 @@ internal static partial class WorkItemScannerServiceLoggingExtensions
     public static partial void LogScannerStarting(this ILogger logger);
 
     [LoggerMessage(
+        EventId = 3,
+        Level = LogLevel.Warning,
+        Message = "Work item scanner: no repos configured - scanner will not run. Configure GitHub:Scan:Repos to enable."
+    )]
+    public static partial void LogNoReposConfigured(this ILogger logger);
+
+    [LoggerMessage(
         EventId = 1,
         Level = LogLevel.Information,
         Message = "Work item scanner service stopping"

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/WorkItemScannerService.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/WorkItemScannerService.cs
@@ -31,6 +31,8 @@ public sealed class WorkItemScannerService : BackgroundService
     {
         if (this._scanOptions.Repos.Count == 0)
         {
+            this._logger.LogNoReposConfigured();
+
             return;
         }
 


### PR DESCRIPTION
## Summary

- Adds a `Warning`-level log message when `WorkItemScannerService` starts with an empty repos list, directing operators to set `GitHub:Scan:Repos`
- Previously the service silently exited, making it impossible to distinguish "scanner disabled by config" from "scanner running but finding nothing"

Closes #50

## Test plan

- [ ] Deploy and check logs — should see the warning if `GitHub:Scan:Repos` is not configured
- [ ] All 129 unit tests pass