### PR TITLE
feat(github): auto-discover repos with write access in WorkItemScanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ## [Unreleased]
 ### Added
 - Work item scanner background service that polls configured GitHub repositories for open pull requests and issues, updating notification state with priority, hold status, and linked PR information
+- Work item scanner auto-discovers GitHub repositories with write access via the API — no longer requires explicit Repos configuration. Uses AllowedOwners, AllowedRepos, and ExcludedRepos filters; empty filters mean scan all accessible repos.
 ### Fixed
 ### Changed
 - Dependencies - Updated Credfeto.Version.Information.Generator to 1.0.124.1183

--- a/src/Credfeto.Dispatcher.GitHub.Tests/BackgroundServices/WorkItemScannerServiceTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/BackgroundServices/WorkItemScannerServiceTests.cs
@@ -20,33 +20,18 @@ public sealed class WorkItemScannerServiceTests : TestBase
         this._scanner = GetSubstitute<IWorkItemScanner>();
     }
 
-    private WorkItemScannerService CreateService(GitHubOptions options)
+    private WorkItemScannerService CreateService(GitHubOptions? options = null)
     {
         return new WorkItemScannerService(
             scanner: this._scanner,
-            options: Options.Create(options),
+            options: Options.Create(options ?? new GitHubOptions()),
             logger: this.GetTypedLogger<WorkItemScannerService>()
         );
     }
 
     [Fact]
-    public async Task DoesNotCallScannerWhenReposIsEmptyAsync()
+    public async Task CallsScannerOnStartupAsync()
     {
-        GitHubOptions options = new() { Scan = new GitHubScanOptions { Repos = [] } };
-        CancellationToken token = TestContext.Current.CancellationToken;
-
-        using WorkItemScannerService service = this.CreateService(options);
-        await service.StartAsync(token);
-        await Task.Delay(millisecondsDelay: 50, cancellationToken: token);
-        await service.StopAsync(token);
-
-        await this._scanner.DidNotReceive().ScanAsync(Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task CallsScannerWhenReposAreConfiguredAsync()
-    {
-        GitHubOptions options = new() { Scan = new GitHubScanOptions { Repos = ["owner/repo"] } };
         TaskCompletionSource scanStarted = new();
 
         this._scanner.ScanAsync(Arg.Any<CancellationToken>())
@@ -59,7 +44,7 @@ public sealed class WorkItemScannerServiceTests : TestBase
 
         CancellationToken token = TestContext.Current.CancellationToken;
 
-        using WorkItemScannerService service = this.CreateService(options);
+        using WorkItemScannerService service = this.CreateService();
         await service.StartAsync(token);
         await scanStarted.Task.WaitAsync(
             timeout: TimeSpan.FromSeconds(5),
@@ -73,7 +58,6 @@ public sealed class WorkItemScannerServiceTests : TestBase
     [Fact]
     public async Task StopsGracefullyWhenScannerThrowsOperationCanceledExceptionAsync()
     {
-        GitHubOptions options = new() { Scan = new GitHubScanOptions { Repos = ["owner/repo"] } };
         TaskCompletionSource scanCalled = new();
 
         this._scanner.ScanAsync(Arg.Any<CancellationToken>())
@@ -86,7 +70,7 @@ public sealed class WorkItemScannerServiceTests : TestBase
 
         CancellationToken token = TestContext.Current.CancellationToken;
 
-        using WorkItemScannerService service = this.CreateService(options);
+        using WorkItemScannerService service = this.CreateService();
         await service.StartAsync(token);
         await scanCalled.Task.WaitAsync(timeout: TimeSpan.FromSeconds(5), cancellationToken: token);
         await service.StopAsync(token);
@@ -97,7 +81,6 @@ public sealed class WorkItemScannerServiceTests : TestBase
     [Fact]
     public async Task HandlesExceptionFromScannerWithoutCrashingAsync()
     {
-        GitHubOptions options = new() { Scan = new GitHubScanOptions { Repos = ["owner/repo"] } };
         TaskCompletionSource exceptionThrown = new();
 
         this._scanner.ScanAsync(Arg.Any<CancellationToken>())
@@ -110,7 +93,7 @@ public sealed class WorkItemScannerServiceTests : TestBase
 
         CancellationToken token = TestContext.Current.CancellationToken;
 
-        using WorkItemScannerService service = this.CreateService(options);
+        using WorkItemScannerService service = this.CreateService();
         await service.StartAsync(token);
         await exceptionThrown.Task.WaitAsync(
             timeout: TimeSpan.FromSeconds(5),

--- a/src/Credfeto.Dispatcher.GitHub.Tests/Services/WorkItemScannerTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/Services/WorkItemScannerTests.cs
@@ -17,7 +17,35 @@ namespace Credfeto.Dispatcher.GitHub.Tests.Services;
 
 public sealed class WorkItemScannerTests : TestBase
 {
+    private const string Owner = "owner";
     private const string Repo = "owner/repo";
+
+    private const string UserReposJson = """
+        [{
+          "full_name": "owner/repo",
+          "archived": false,
+          "disabled": false,
+          "permissions": {"push": true}
+        }]
+        """;
+
+    private const string ReadOnlyRepoJson = """
+        [{
+          "full_name": "owner/repo",
+          "archived": false,
+          "disabled": false,
+          "permissions": {"push": false}
+        }]
+        """;
+
+    private const string ArchivedRepoJson = """
+        [{
+          "full_name": "owner/repo",
+          "archived": true,
+          "disabled": false,
+          "permissions": {"push": true}
+        }]
+        """;
 
     private const string OpenPrJson = """
         [{
@@ -147,6 +175,23 @@ public sealed class WorkItemScannerTests : TestBase
         }]
         """;
 
+    private const string TwoReposJson = """
+        [
+          {
+            "full_name": "owner/repo",
+            "archived": false,
+            "disabled": false,
+            "permissions": {"push": true}
+          },
+          {
+            "full_name": "owner/repo2",
+            "archived": false,
+            "disabled": false,
+            "permissions": {"push": true}
+          }
+        ]
+        """;
+
     private const string EmptyJson = "[]";
 
     private readonly System.Net.Http.IHttpClientFactory _httpClientFactory;
@@ -163,9 +208,7 @@ public sealed class WorkItemScannerTests : TestBase
         return new WorkItemScanner(
             httpClientFactory: this._httpClientFactory,
             notificationStateTracker: this._notificationStateTracker,
-            options: Options.Create(
-                options ?? new GitHubOptions { Scan = new GitHubScanOptions { Repos = [Repo] } }
-            ),
+            options: Options.Create(options ?? new GitHubOptions()),
             logger: this.GetTypedLogger<WorkItemScanner>()
         );
     }
@@ -199,11 +242,12 @@ public sealed class WorkItemScannerTests : TestBase
     }
 
     [Fact]
-    public async Task ScanAsync_WithNoRepos_MakesNoStateUpdatesAsync()
+    public async Task ScanAsync_WhenRepoDiscoveryReturnsEmpty_MakesNoStateUpdatesAsync()
     {
-        WorkItemScanner scanner = this.CreateScanner(
-            new GitHubOptions { Scan = new GitHubScanOptions { Repos = [] } }
-        );
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, EmptyJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient);
+
+        WorkItemScanner scanner = this.CreateScanner();
 
         await scanner.ScanAsync(this.CancellationToken());
 
@@ -232,11 +276,137 @@ public sealed class WorkItemScannerTests : TestBase
     }
 
     [Fact]
+    public async Task ScanAsync_WhenRepoIsReadOnly_MakesNoStateUpdatesAsync()
+    {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, ReadOnlyRepoJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient);
+
+        WorkItemScanner scanner = this.CreateScanner();
+
+        await scanner.ScanAsync(this.CancellationToken());
+
+        await this
+            ._notificationStateTracker.DidNotReceive()
+            .UpdatePullRequestStateAsync(
+                repository: Arg.Any<string>(),
+                pullRequestNumber: Arg.Any<int>(),
+                status: Arg.Any<string>(),
+                priority: Arg.Any<WorkPriority>(),
+                isOnHold: Arg.Any<bool>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task ScanAsync_WhenRepoIsArchived_MakesNoStateUpdatesAsync()
+    {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, ArchivedRepoJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient);
+
+        WorkItemScanner scanner = this.CreateScanner();
+
+        await scanner.ScanAsync(this.CancellationToken());
+
+        await this
+            ._notificationStateTracker.DidNotReceive()
+            .UpdatePullRequestStateAsync(
+                repository: Arg.Any<string>(),
+                pullRequestNumber: Arg.Any<int>(),
+                status: Arg.Any<string>(),
+                priority: Arg.Any<WorkPriority>(),
+                isOnHold: Arg.Any<bool>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task ScanAsync_WhenOwnerNotInAllowedOwners_MakesNoStateUpdatesAsync()
+    {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient);
+
+        GitHubOptions options = new()
+        {
+            Filter = new GitHubFilterOptions { AllowedOwners = ["other-owner"] },
+        };
+
+        WorkItemScanner scanner = this.CreateScanner(options);
+
+        await scanner.ScanAsync(this.CancellationToken());
+
+        await this
+            ._notificationStateTracker.DidNotReceive()
+            .UpdatePullRequestStateAsync(
+                repository: Arg.Any<string>(),
+                pullRequestNumber: Arg.Any<int>(),
+                status: Arg.Any<string>(),
+                priority: Arg.Any<WorkPriority>(),
+                isOnHold: Arg.Any<bool>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task ScanAsync_WhenRepoNotInAllowedRepos_MakesNoStateUpdatesAsync()
+    {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient);
+
+        GitHubOptions options = new()
+        {
+            Filter = new GitHubFilterOptions { AllowedRepos = ["owner/other-repo"] },
+        };
+
+        WorkItemScanner scanner = this.CreateScanner(options);
+
+        await scanner.ScanAsync(this.CancellationToken());
+
+        await this
+            ._notificationStateTracker.DidNotReceive()
+            .UpdatePullRequestStateAsync(
+                repository: Arg.Any<string>(),
+                pullRequestNumber: Arg.Any<int>(),
+                status: Arg.Any<string>(),
+                priority: Arg.Any<WorkPriority>(),
+                isOnHold: Arg.Any<bool>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task ScanAsync_WhenRepoIsExcluded_MakesNoStateUpdatesAsync()
+    {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient);
+
+        GitHubOptions options = new()
+        {
+            Filter = new GitHubFilterOptions { ExcludedRepos = [Repo] },
+        };
+
+        WorkItemScanner scanner = this.CreateScanner(options);
+
+        await scanner.ScanAsync(this.CancellationToken());
+
+        await this
+            ._notificationStateTracker.DidNotReceive()
+            .UpdatePullRequestStateAsync(
+                repository: Arg.Any<string>(),
+                pullRequestNumber: Arg.Any<int>(),
+                status: Arg.Any<string>(),
+                priority: Arg.Any<WorkPriority>(),
+                isOnHold: Arg.Any<bool>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
     public async Task ScanAsync_WithOpenPullRequest_CallsUpdateWithOpenStatusAsync()
     {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
         using HttpClient prClient = CreateClient(HttpStatusCode.OK, OpenPrJson);
         using HttpClient issueClient = CreateClient(HttpStatusCode.OK, EmptyJson);
-        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, issueClient);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
 
         WorkItemScanner scanner = this.CreateScanner();
 
@@ -257,9 +427,10 @@ public sealed class WorkItemScannerTests : TestBase
     [Fact]
     public async Task ScanAsync_WithDraftPullRequest_CallsUpdateWithDraftStatusAsync()
     {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
         using HttpClient prClient = CreateClient(HttpStatusCode.OK, DraftPrJson);
         using HttpClient issueClient = CreateClient(HttpStatusCode.OK, EmptyJson);
-        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, issueClient);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
 
         WorkItemScanner scanner = this.CreateScanner();
 
@@ -280,9 +451,10 @@ public sealed class WorkItemScannerTests : TestBase
     [Fact]
     public async Task ScanAsync_WithUrgentPriorityLabel_CallsUpdateWithUrgentPriorityAsync()
     {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
         using HttpClient prClient = CreateClient(HttpStatusCode.OK, PrWithUrgentLabelJson);
         using HttpClient issueClient = CreateClient(HttpStatusCode.OK, EmptyJson);
-        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, issueClient);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
 
         WorkItemScanner scanner = this.CreateScanner();
 
@@ -303,13 +475,13 @@ public sealed class WorkItemScannerTests : TestBase
     [Fact]
     public async Task ScanAsync_WithOnHoldLabel_CallsUpdateWithIsOnHoldTrueAsync()
     {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
         using HttpClient prClient = CreateClient(HttpStatusCode.OK, PrWithOnHoldLabelJson);
         using HttpClient issueClient = CreateClient(HttpStatusCode.OK, EmptyJson);
-        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, issueClient);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
 
         GitHubOptions options = new()
         {
-            Scan = new GitHubScanOptions { Repos = [Repo] },
             Filter = new GitHubFilterOptions { NoWorkFilter = ["on-hold"] },
         };
 
@@ -332,13 +504,13 @@ public sealed class WorkItemScannerTests : TestBase
     [Fact]
     public async Task ScanAsync_WithMatchingLabelFilter_CallsUpdateAsync()
     {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
         using HttpClient prClient = CreateClient(HttpStatusCode.OK, PrWithAiWorkLabelJson);
         using HttpClient issueClient = CreateClient(HttpStatusCode.OK, EmptyJson);
-        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, issueClient);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
 
         GitHubOptions options = new()
         {
-            Scan = new GitHubScanOptions { Repos = [Repo] },
             Filter = new GitHubFilterOptions { LabelFilter = ["AI-Work"] },
         };
 
@@ -361,13 +533,13 @@ public sealed class WorkItemScannerTests : TestBase
     [Fact]
     public async Task ScanAsync_WithNonMatchingLabelFilter_DoesNotCallUpdateAsync()
     {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
         using HttpClient prClient = CreateClient(HttpStatusCode.OK, PrWithUnrelatedLabelJson);
         using HttpClient issueClient = CreateClient(HttpStatusCode.OK, EmptyJson);
-        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, issueClient);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
 
         GitHubOptions options = new()
         {
-            Scan = new GitHubScanOptions { Repos = [Repo] },
             Filter = new GitHubFilterOptions { LabelFilter = ["AI-Work"] },
         };
 
@@ -390,9 +562,10 @@ public sealed class WorkItemScannerTests : TestBase
     [Fact]
     public async Task ScanAsync_WithPullRequestApiFailure_DoesNotThrowAsync()
     {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
         using HttpClient prClient = CreateClient(HttpStatusCode.InternalServerError);
         using HttpClient issueClient = CreateClient(HttpStatusCode.OK, EmptyJson);
-        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, issueClient);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
 
         WorkItemScanner scanner = this.CreateScanner();
 
@@ -413,9 +586,10 @@ public sealed class WorkItemScannerTests : TestBase
     [Fact]
     public async Task ScanAsync_WithOpenIssue_CallsUpdateIssueStateAsync()
     {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
         using HttpClient prClient = CreateClient(HttpStatusCode.OK, EmptyJson);
         using HttpClient issueClient = CreateClient(HttpStatusCode.OK, OpenIssueJson);
-        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, issueClient);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
 
         WorkItemScanner scanner = this.CreateScanner();
 
@@ -437,9 +611,10 @@ public sealed class WorkItemScannerTests : TestBase
     [Fact]
     public async Task ScanAsync_WithIssueLinkedToPr_SkipsIssueAsync()
     {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
         using HttpClient prClient = CreateClient(HttpStatusCode.OK, EmptyJson);
         using HttpClient issueClient = CreateClient(HttpStatusCode.OK, IssueWithLinkedPrJson);
-        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, issueClient);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
 
         WorkItemScanner scanner = this.CreateScanner();
 
@@ -461,9 +636,10 @@ public sealed class WorkItemScannerTests : TestBase
     [Fact]
     public async Task ScanAsync_WithIssueApiFailure_DoesNotThrowAsync()
     {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
         using HttpClient prClient = CreateClient(HttpStatusCode.OK, EmptyJson);
         using HttpClient issueClient = CreateClient(HttpStatusCode.InternalServerError);
-        this._httpClientFactory.CreateClient("GitHub").Returns(prClient, issueClient);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
 
         WorkItemScanner scanner = this.CreateScanner();
 
@@ -488,6 +664,7 @@ public sealed class WorkItemScannerTests : TestBase
         const string page2Url =
             "https://api.github.com/repos/owner/repo/pulls?state=open&per_page=100&page=2";
 
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
         using HttpClient prPage1Client = CreateClient(
             HttpStatusCode.OK,
             PrPage1Json,
@@ -496,7 +673,7 @@ public sealed class WorkItemScannerTests : TestBase
         using HttpClient prPage2Client = CreateClient(HttpStatusCode.OK, PrPage2Json);
         using HttpClient issueClient = CreateClient(HttpStatusCode.OK, EmptyJson);
         this._httpClientFactory.CreateClient("GitHub")
-            .Returns(prPage1Client, prPage2Client, issueClient);
+            .Returns(repoClient, prPage1Client, prPage2Client, issueClient);
 
         WorkItemScanner scanner = this.CreateScanner();
 
@@ -526,20 +703,19 @@ public sealed class WorkItemScannerTests : TestBase
     }
 
     [Fact]
-    public async Task ScanAsync_WithMultipleRepos_ScansEachRepoAsync()
+    public async Task ScanAsync_WithMultipleDiscoveredRepos_ScansEachRepoAsync()
     {
         const string repo2 = "owner/repo2";
 
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, TwoReposJson);
         using HttpClient prClient1 = CreateClient(HttpStatusCode.OK, EmptyJson);
         using HttpClient issueClient1 = CreateClient(HttpStatusCode.OK, OpenIssueJson);
         using HttpClient prClient2 = CreateClient(HttpStatusCode.OK, EmptyJson);
         using HttpClient issueClient2 = CreateClient(HttpStatusCode.OK, EmptyJson);
         this._httpClientFactory.CreateClient("GitHub")
-            .Returns(prClient1, issueClient1, prClient2, issueClient2);
+            .Returns(repoClient, prClient1, issueClient1, prClient2, issueClient2);
 
-        GitHubOptions options = new() { Scan = new GitHubScanOptions { Repos = [Repo, repo2] } };
-
-        WorkItemScanner scanner = this.CreateScanner(options);
+        WorkItemScanner scanner = this.CreateScanner();
 
         await scanner.ScanAsync(this.CancellationToken());
 
@@ -552,6 +728,47 @@ public sealed class WorkItemScannerTests : TestBase
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
                 hasLinkedPr: Arg.Any<bool>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
+
+        await this
+            ._notificationStateTracker.DidNotReceive()
+            .UpdateIssueStateAsync(
+                repository: repo2,
+                issueNumber: Arg.Any<int>(),
+                status: Arg.Any<string>(),
+                priority: Arg.Any<WorkPriority>(),
+                isOnHold: Arg.Any<bool>(),
+                hasLinkedPr: Arg.Any<bool>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task ScanAsync_WhenAllowedOwnerMatches_ScansRepoAsync()
+    {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
+        using HttpClient prClient = CreateClient(HttpStatusCode.OK, OpenPrJson);
+        using HttpClient issueClient = CreateClient(HttpStatusCode.OK, EmptyJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
+
+        GitHubOptions options = new()
+        {
+            Filter = new GitHubFilterOptions { AllowedOwners = [Owner] },
+        };
+
+        WorkItemScanner scanner = this.CreateScanner(options);
+
+        await scanner.ScanAsync(this.CancellationToken());
+
+        await this
+            ._notificationStateTracker.Received(1)
+            .UpdatePullRequestStateAsync(
+                repository: Repo,
+                pullRequestNumber: 1,
+                status: Arg.Any<string>(),
+                priority: Arg.Any<WorkPriority>(),
+                isOnHold: Arg.Any<bool>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/WorkItemScannerService.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/WorkItemScannerService.cs
@@ -29,11 +29,6 @@ public sealed class WorkItemScannerService : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        if (this._scanOptions.Repos.Count == 0)
-        {
-            return;
-        }
-
         this._logger.LogScannerStarting();
 
         while (!stoppingToken.IsCancellationRequested)

--- a/src/Credfeto.Dispatcher.GitHub/Configuration/GitHubScanOptions.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Configuration/GitHubScanOptions.cs
@@ -1,12 +1,9 @@
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Credfeto.Dispatcher.GitHub.Configuration;
 
-[DebuggerDisplay("Repos: {Repos.Count}, ScanIntervalSeconds: {ScanIntervalSeconds}")]
+[DebuggerDisplay("ScanIntervalSeconds: {ScanIntervalSeconds}")]
 public sealed class GitHubScanOptions
 {
-    public IReadOnlyList<string> Repos { get; init; } = [];
-
     public int ScanIntervalSeconds { get; init; } = 3600;
 }

--- a/src/Credfeto.Dispatcher.GitHub/Models/ApiRepoPermissions.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Models/ApiRepoPermissions.cs
@@ -1,0 +1,7 @@
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace Credfeto.Dispatcher.GitHub.Models;
+
+[DebuggerDisplay("Push={Push}")]
+internal sealed record ApiRepoPermissions([property: JsonPropertyName("push")] bool Push);

--- a/src/Credfeto.Dispatcher.GitHub/Models/ApiUserRepo.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Models/ApiUserRepo.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace Credfeto.Dispatcher.GitHub.Models;
+
+[DebuggerDisplay("{FullName}: Archived={Archived}, Push={Permissions?.Push}")]
+internal sealed record ApiUserRepo(
+    [property: JsonPropertyName("full_name")] string FullName,
+    [property: JsonPropertyName("archived")] bool Archived,
+    [property: JsonPropertyName("disabled")] bool Disabled,
+    [property: JsonPropertyName("permissions")] ApiRepoPermissions? Permissions
+);

--- a/src/Credfeto.Dispatcher.GitHub/Models/NotificationSerializerContext.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Models/NotificationSerializerContext.cs
@@ -11,5 +11,6 @@ namespace Credfeto.Dispatcher.GitHub.Models;
 [JsonSerializable(typeof(ApiIssue))]
 [JsonSerializable(typeof(ApiIssue[]))]
 [JsonSerializable(typeof(ApiIssuePullRequest))]
+[JsonSerializable(typeof(ApiUserRepo[]))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 internal sealed partial class NotificationSerializerContext : JsonSerializerContext;

--- a/src/Credfeto.Dispatcher.GitHub/Services/LoggingExtensions/WorkItemScannerLoggingExtensions.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Services/LoggingExtensions/WorkItemScannerLoggingExtensions.cs
@@ -12,6 +12,20 @@ internal static partial class WorkItemScannerLoggingExtensions
     public static partial void LogScanningRepo(this ILogger logger, string repo);
 
     [LoggerMessage(
+        EventId = 5,
+        Level = LogLevel.Information,
+        Message = "Discovered {Count} repos with write access to scan"
+    )]
+    public static partial void LogDiscoveredRepos(this ILogger logger, int count);
+
+    [LoggerMessage(
+        EventId = 6,
+        Level = LogLevel.Warning,
+        Message = "No repos with write access discovered. Check the token permissions and AllowedOwners/AllowedRepos/ExcludedRepos filter configuration."
+    )]
+    public static partial void LogNoReposDiscovered(this ILogger logger);
+
+    [LoggerMessage(
         EventId = 1,
         Level = LogLevel.Debug,
         Message = "Scanned PR #{Number} in {Repo}: status={Status}"

--- a/src/Credfeto.Dispatcher.GitHub/Services/WorkItemScanner.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Services/WorkItemScanner.cs
@@ -39,12 +39,124 @@ public sealed class WorkItemScanner : IWorkItemScanner
 
     public async Task ScanAsync(CancellationToken cancellationToken)
     {
-        foreach (string repo in this._options.Scan.Repos)
+        IReadOnlyList<string> repos = await this.DiscoverReposAsync(cancellationToken);
+
+        if (repos.Count == 0)
+        {
+            this._logger.LogNoReposDiscovered();
+
+            return;
+        }
+
+        this._logger.LogDiscoveredRepos(count: repos.Count);
+
+        foreach (string repo in repos)
         {
             await this.ScanRepoAsync(repo: repo, cancellationToken: cancellationToken);
         }
 
         this._logger.LogScanComplete();
+    }
+
+    private async Task<IReadOnlyList<string>> DiscoverReposAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        List<string> repos = [];
+        string? url = "user/repos?per_page=100";
+
+        while (url is not null)
+        {
+            (ApiUserRepo[]? items, string? nextUrl) = await this.GetPagedAsync(
+                url: url,
+                jsonTypeInfo: NotificationSerializerContext.Default.ApiUserRepoArray,
+                cancellationToken: cancellationToken
+            );
+
+            if (items is null)
+            {
+                break;
+            }
+
+            foreach (ApiUserRepo repo in items)
+            {
+                if (
+                    !repo.Archived
+                    && !repo.Disabled
+                    && repo.Permissions?.Push == true
+                    && this.PassesRepoFilter(repo.FullName)
+                )
+                {
+                    repos.Add(repo.FullName);
+                }
+            }
+
+            url = nextUrl;
+        }
+
+        return repos;
+    }
+
+    private bool PassesRepoFilter(string fullName)
+    {
+        if (this._options.Filter.AllowedOwners.Count > 0)
+        {
+            string owner = GetOwner(fullName);
+
+            if (
+                !this._options.Filter.AllowedOwners.Any(o =>
+                    string.Equals(
+                        a: o,
+                        b: owner,
+                        comparisonType: StringComparison.OrdinalIgnoreCase
+                    )
+                )
+            )
+            {
+                return false;
+            }
+        }
+
+        if (this._options.Filter.AllowedRepos.Count > 0)
+        {
+            if (
+                !this._options.Filter.AllowedRepos.Any(r =>
+                    string.Equals(
+                        a: r,
+                        b: fullName,
+                        comparisonType: StringComparison.OrdinalIgnoreCase
+                    )
+                )
+            )
+            {
+                return false;
+            }
+        }
+
+        if (this._options.Filter.ExcludedRepos.Count > 0)
+        {
+            if (
+                this._options.Filter.ExcludedRepos.Any(r =>
+                    string.Equals(
+                        a: r,
+                        b: fullName,
+                        comparisonType: StringComparison.OrdinalIgnoreCase
+                    )
+                )
+            )
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string GetOwner(string fullName)
+    {
+        int slash = fullName.IndexOf(value: '/', comparisonType: StringComparison.Ordinal);
+
+        return slash >= 0 ? fullName[..slash] : fullName;
     }
 
     private async Task ScanRepoAsync(string repo, CancellationToken cancellationToken)
@@ -70,15 +182,6 @@ public sealed class WorkItemScanner : IWorkItemScanner
             if (items is null)
             {
                 break;
-            }
-
-            if (this._logger.IsEnabled(LogLevel.Information))
-            {
-                this._logger.LogInformation(
-                    "PR scan page: {Count} items from {Url}",
-                    items.Length,
-                    url
-                );
             }
 
             foreach (ApiPullRequest pr in items)

--- a/src/Credfeto.Dispatcher.GitHub/Services/WorkItemScanner.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Services/WorkItemScanner.cs
@@ -63,7 +63,7 @@ public sealed class WorkItemScanner : IWorkItemScanner
     )
     {
         List<string> repos = [];
-        string? url = "user/repos?per_page=100";
+        string? url = "user/repos?affiliation=owner,collaborator,organization_member&per_page=100";
 
         while (url is not null)
         {

--- a/src/Credfeto.Dispatcher.Server/appsettings.json
+++ b/src/Credfeto.Dispatcher.Server/appsettings.json
@@ -18,7 +18,6 @@
       "ExcludedRepos": []
     },
     "Scan": {
-      "Repos": [],
       "ScanIntervalSeconds": 3600
     }
   },


### PR DESCRIPTION
## Summary

- Replaces the static `GitHub:Scan:Repos` list with a call to `GET /user/repos` — the scanner discovers all repos the token has push access to automatically
- Archived and disabled repos are excluded
- The existing `AllowedOwners`, `AllowedRepos`, and `ExcludedRepos` filter options control which discovered repos get scanned:
  - Empty (default) → scan everything with write access
  - `AllowedOwners` set → restrict to those owners only
  - `AllowedRepos` set → restrict to those specific repos only
  - `ExcludedRepos` → always skip those, regardless of other filters
- Logs a Warning if discovery returns zero scannable repos (bad token, overly strict filters, etc.)
- Removes `GitHubScanOptions.Repos` entirely; `WorkItemScannerService` now always starts the scan loop

Closes #52

## Test plan

- [ ] 134 unit tests pass (5 new filter-scenario tests added)
- [ ] Deploy — logs should show "Discovered N repos with write access to scan" on startup without any config changes
- [ ] Set `AllowedOwners` / `ExcludedRepos` in config to verify filtering works