### PR TITLE
feat: store whether PR branch is up-to-date in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Work item scanner background service that polls configured GitHub repositories for open pull requests and issues, updating notification state with priority, hold status, and linked PR information
 - Work item scanner auto-discovers GitHub repositories with write access via the API — no longer requires explicit Repos configuration. Uses AllowedOwners, AllowedRepos, and ExcludedRepos filters; empty filters mean scan all accessible repos.
 - Enable PublishTrimmed for release builds, convert MaxLength data annotations to fluent API, and update options properties to use set accessors for trim-compatible configuration binding
+- Store whether a pull request branch is up-to-date with its base in the database, exposed via WorkItem and the priorities endpoint so consumers can decide whether to rebase
 ### Fixed
 - EF Core change-tracking comparers trimmed away at publish time causing MissingMethodException at startup; preserve EF Core and Ben.Demystifier assemblies as trimmer roots
 ### Changed
@@ -26,6 +27,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Dependencies - Updated Credfeto.Services.Startup to 1.1.145.1592
 - Dependencies - Updated FunFair.Test.Common to 6.2.22.2198
 - Dependencies - Updated FunFair.Test.Source.Generator to 6.2.22.2198
+- Migrated NotificationStateTracker and GitHubPollingWorker from deprecated ICurrentTimeSource to System.TimeProvider
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Work item scanner auto-discovers GitHub repositories with write access via the API — no longer requires explicit Repos configuration. Uses AllowedOwners, AllowedRepos, and ExcludedRepos filters; empty filters mean scan all accessible repos.
 - Enable PublishTrimmed for release builds, convert MaxLength data annotations to fluent API, and update options properties to use set accessors for trim-compatible configuration binding
 - Store whether a pull request branch is up-to-date with its base in the database, exposed via WorkItem and the priorities endpoint so consumers can decide whether to rebase
+- LastUpdated field included in /priorities API response work items
 ### Fixed
 - EF Core change-tracking comparers trimmed away at publish time causing MissingMethodException at startup; preserve EF Core and Ben.Demystifier assemblies as trimmer roots
 ### Changed

--- a/src/Credfeto.Dispatcher.GitHub.DataTypes/PullRequestDetails.cs
+++ b/src/Credfeto.Dispatcher.GitHub.DataTypes/PullRequestDetails.cs
@@ -20,5 +20,6 @@ public sealed record PullRequestDetails(
     string? ReviewAuthor,
     Uri? ReviewUrl,
     string? FailedRunName,
-    Uri? FailedRunUrl
+    Uri? FailedRunUrl,
+    bool? IsUpToDate
 );

--- a/src/Credfeto.Dispatcher.GitHub.DataTypes/WorkItem.cs
+++ b/src/Credfeto.Dispatcher.GitHub.DataTypes/WorkItem.cs
@@ -10,5 +10,6 @@ public sealed record WorkItem(
     string ItemType,
     WorkPriority Priority,
     DateTimeOffset FirstSeen,
+    DateTimeOffset LastUpdated,
     bool? IsUpToDate
 );

--- a/src/Credfeto.Dispatcher.GitHub.DataTypes/WorkItem.cs
+++ b/src/Credfeto.Dispatcher.GitHub.DataTypes/WorkItem.cs
@@ -9,5 +9,6 @@ public sealed record WorkItem(
     int Id,
     string ItemType,
     WorkPriority Priority,
-    DateTimeOffset FirstSeen
+    DateTimeOffset FirstSeen,
+    bool? IsUpToDate
 );

--- a/src/Credfeto.Dispatcher.GitHub.Interfaces/INotificationStateTracker.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Interfaces/INotificationStateTracker.cs
@@ -19,6 +19,7 @@ public interface INotificationStateTracker
         string status,
         WorkPriority priority,
         bool isOnHold,
+        bool? isUpToDate,
         CancellationToken cancellationToken
     );
 

--- a/src/Credfeto.Dispatcher.GitHub.Tests/BackgroundServices/GitHubPollingWorkerTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/BackgroundServices/GitHubPollingWorkerTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Credfeto.Date.Interfaces;
 using Credfeto.Dispatcher.Discord.DataTypes;
 using Credfeto.Dispatcher.Discord.Interfaces;
 using Credfeto.Dispatcher.GitHub.BackgroundServices;
@@ -12,6 +11,7 @@ using Credfeto.Dispatcher.GitHub.Interfaces;
 using FunFair.Test.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
 
@@ -117,7 +117,8 @@ public sealed class GitHubPollingWorkerTests : TestBase
             ReviewAuthor: null,
             ReviewUrl: null,
             FailedRunName: null,
-            FailedRunUrl: null
+            FailedRunUrl: null,
+            IsUpToDate: null
         );
     }
 
@@ -138,7 +139,8 @@ public sealed class GitHubPollingWorkerTests : TestBase
             ReviewAuthor: null,
             ReviewUrl: null,
             FailedRunName: null,
-            FailedRunUrl: null
+            FailedRunUrl: null,
+            IsUpToDate: null
         );
     }
 
@@ -174,20 +176,17 @@ public sealed class GitHubPollingWorkerTests : TestBase
         IIssueDetailFetcher? issueFetcher = null
     )
     {
-        ICurrentTimeSource currentTimeSource = GetSubstitute<ICurrentTimeSource>();
-        currentTimeSource
-            .UtcNow()
-            .Returns(
-                new DateTimeOffset(
-                    year: 2024,
-                    month: 1,
-                    day: 1,
-                    hour: 0,
-                    minute: 0,
-                    second: 0,
-                    offset: TimeSpan.Zero
-                )
-            );
+        FakeTimeProvider timeProvider = new(
+            startDateTime: new DateTimeOffset(
+                year: 2024,
+                month: 1,
+                day: 1,
+                hour: 0,
+                minute: 0,
+                second: 0,
+                offset: TimeSpan.Zero
+            )
+        );
 
         return new GitHubPollingWorker(
             poller: poller,
@@ -197,7 +196,7 @@ public sealed class GitHubPollingWorkerTests : TestBase
             issueDetailFetcher: issueFetcher ?? new FakeIssueFetcher(result: null),
             notificationStateTracker: this._stateTracker,
             pendingNotificationStore: new FakePendingNotificationStore(),
-            currentTimeSource: currentTimeSource,
+            timeProvider: timeProvider,
             options: Options.Create(new GitHubOptions { PollIntervalSeconds = 30 }),
             notificationQueueOptions: Options.Create(
                 new NotificationQueueOptions { DelaySeconds = 0 }

--- a/src/Credfeto.Dispatcher.GitHub.Tests/Credfeto.Dispatcher.GitHub.Tests.csproj
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/Credfeto.Dispatcher.GitHub.Tests.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FunFair.Test.Common" Version="6.2.22.2198" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>

--- a/src/Credfeto.Dispatcher.GitHub.Tests/Services/PullRequestDetailFetcherTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/Services/PullRequestDetailFetcherTests.cs
@@ -25,7 +25,8 @@ public sealed class PullRequestDetailFetcherTests : TestBase
           "html_url": "https://github.com/owner/repo/pull/42",
           "assignees": [],
           "labels": [],
-          "head": {"sha": "abc123"}
+          "head": {"sha": "abc123"},
+          "mergeable_state": "clean"
         }
         """;
 
@@ -38,7 +39,8 @@ public sealed class PullRequestDetailFetcherTests : TestBase
           "html_url": "https://github.com/owner/repo/pull/42",
           "assignees": [],
           "labels": [],
-          "head": {"sha": "abc123"}
+          "head": {"sha": "abc123"},
+          "mergeable_state": "draft"
         }
         """;
 
@@ -47,6 +49,48 @@ public sealed class PullRequestDetailFetcherTests : TestBase
           "number": 42,
           "title": "Test PR",
           "state": "closed",
+          "draft": false,
+          "html_url": "https://github.com/owner/repo/pull/42",
+          "assignees": [],
+          "labels": [],
+          "head": {"sha": "abc123"},
+          "mergeable_state": "clean"
+        }
+        """;
+
+    private const string BehindPrJson = """
+        {
+          "number": 42,
+          "title": "Test PR",
+          "state": "open",
+          "draft": false,
+          "html_url": "https://github.com/owner/repo/pull/42",
+          "assignees": [],
+          "labels": [],
+          "head": {"sha": "abc123"},
+          "mergeable_state": "behind"
+        }
+        """;
+
+    private const string UnknownMergeStatePrJson = """
+        {
+          "number": 42,
+          "title": "Test PR",
+          "state": "open",
+          "draft": false,
+          "html_url": "https://github.com/owner/repo/pull/42",
+          "assignees": [],
+          "labels": [],
+          "head": {"sha": "abc123"},
+          "mergeable_state": "unknown"
+        }
+        """;
+
+    private const string NullMergeStatePrJson = """
+        {
+          "number": 42,
+          "title": "Test PR",
+          "state": "open",
           "draft": false,
           "html_url": "https://github.com/owner/repo/pull/42",
           "assignees": [],
@@ -64,7 +108,8 @@ public sealed class PullRequestDetailFetcherTests : TestBase
           "html_url": "https://github.com/owner/repo/pull/42",
           "assignees": [{"login": "alice"}, {"login": "bob"}],
           "labels": [],
-          "head": {"sha": "abc123"}
+          "head": {"sha": "abc123"},
+          "mergeable_state": "clean"
         }
         """;
 
@@ -77,7 +122,8 @@ public sealed class PullRequestDetailFetcherTests : TestBase
           "html_url": "https://github.com/owner/repo/pull/42",
           "assignees": [],
           "labels": [{"name": "bug"}, {"name": "enhancement"}],
-          "head": {"sha": "abc123"}
+          "head": {"sha": "abc123"},
+          "mergeable_state": "clean"
         }
         """;
 
@@ -537,5 +583,73 @@ public sealed class PullRequestDetailFetcherTests : TestBase
             result.CommentBody.EndsWith('…'),
             userMessage: "Expected body to end with ellipsis"
         );
+    }
+
+    [Fact]
+    public async Task IsUpToDateIsTrueWhenMergeableStateIsCleanAsync()
+    {
+        using HttpClient client = CreateClient(HttpStatusCode.OK, OpenPrJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(client);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "mention");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(
+            notification: notification,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: true, actual: result.IsUpToDate);
+    }
+
+    [Fact]
+    public async Task IsUpToDateIsFalseWhenMergeableStateIsBehindAsync()
+    {
+        using HttpClient client = CreateClient(HttpStatusCode.OK, BehindPrJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(client);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "mention");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(
+            notification: notification,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.NotNull(result);
+        Assert.Equal(expected: false, actual: result.IsUpToDate);
+    }
+
+    [Fact]
+    public async Task IsUpToDateIsNullWhenMergeableStateIsUnknownAsync()
+    {
+        using HttpClient client = CreateClient(HttpStatusCode.OK, UnknownMergeStatePrJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(client);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "mention");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(
+            notification: notification,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.NotNull(result);
+        Assert.Null(result.IsUpToDate);
+    }
+
+    [Fact]
+    public async Task IsUpToDateIsNullWhenMergeableStateIsAbsentAsync()
+    {
+        using HttpClient client = CreateClient(HttpStatusCode.OK, NullMergeStatePrJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(client);
+
+        GitHubNotification notification = BuildNotification(type: "PullRequest", reason: "mention");
+
+        PullRequestDetails? result = await this._fetcher.FetchAsync(
+            notification: notification,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.NotNull(result);
+        Assert.Null(result.IsUpToDate);
     }
 }

--- a/src/Credfeto.Dispatcher.GitHub.Tests/Services/WorkItemScannerTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/Services/WorkItemScannerTests.cs
@@ -259,6 +259,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
 
@@ -293,6 +294,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }
@@ -315,6 +317,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }
@@ -342,6 +345,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }
@@ -369,6 +373,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }
@@ -396,6 +401,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }
@@ -420,6 +426,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: "Open",
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }
@@ -444,6 +451,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: "Draft",
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }
@@ -468,6 +476,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: WorkPriority.Urgent,
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }
@@ -497,6 +506,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: true,
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }
@@ -526,6 +536,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }
@@ -555,6 +566,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }
@@ -579,6 +591,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }
@@ -687,6 +700,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
 
@@ -698,6 +712,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }
@@ -769,6 +784,7 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );
     }

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/GitHubPollingWorker.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/GitHubPollingWorker.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
-using Credfeto.Date.Interfaces;
 using Credfeto.Dispatcher.Discord.DataTypes;
 using Credfeto.Dispatcher.Discord.Interfaces;
 using Credfeto.Dispatcher.GitHub.BackgroundServices.LoggingExtensions;
@@ -22,7 +21,6 @@ public sealed class GitHubPollingWorker : BackgroundService
     private const string IssueType = "Issue";
     private const int EmbedColour = 0x5865F2;
 
-    private readonly ICurrentTimeSource _currentTimeSource;
     private readonly IDiscordDispatcher _discordDispatcher;
     private readonly IIssueDetailFetcher _issueDetailFetcher;
     private readonly ILogger<GitHubPollingWorker> _logger;
@@ -33,6 +31,7 @@ public sealed class GitHubPollingWorker : BackgroundService
     private readonly GitHubOptions _options;
     private readonly INotificationPoller _poller;
     private readonly IPullRequestDetailFetcher _pullRequestDetailFetcher;
+    private readonly TimeProvider _timeProvider;
 
     public GitHubPollingWorker(
         INotificationPoller poller,
@@ -42,7 +41,7 @@ public sealed class GitHubPollingWorker : BackgroundService
         IIssueDetailFetcher issueDetailFetcher,
         INotificationStateTracker notificationStateTracker,
         IPendingNotificationStore pendingNotificationStore,
-        ICurrentTimeSource currentTimeSource,
+        TimeProvider timeProvider,
         IOptions<GitHubOptions> options,
         IOptions<NotificationQueueOptions> notificationQueueOptions,
         ILogger<GitHubPollingWorker> logger
@@ -55,7 +54,7 @@ public sealed class GitHubPollingWorker : BackgroundService
         this._issueDetailFetcher = issueDetailFetcher;
         this._notificationStateTracker = notificationStateTracker;
         this._pendingNotificationStore = pendingNotificationStore;
-        this._currentTimeSource = currentTimeSource;
+        this._timeProvider = timeProvider;
         this._options = options.Value;
         this._notificationQueueOptions = notificationQueueOptions.Value;
         this._logger = logger;
@@ -105,7 +104,7 @@ public sealed class GitHubPollingWorker : BackgroundService
             this._notificationQueueOptions.DelaySeconds > 0
                 ? this._notificationQueueOptions.DelaySeconds
                 : 300;
-        DateTimeOffset dispatchAfter = this._currentTimeSource.UtcNow().AddSeconds(delaySeconds);
+        DateTimeOffset dispatchAfter = this._timeProvider.GetUtcNow().AddSeconds(delaySeconds);
 
         foreach (GitHubNotification notification in notifications)
         {
@@ -134,7 +133,7 @@ public sealed class GitHubPollingWorker : BackgroundService
 
     private async ValueTask DispatchReadyItemsAsync(CancellationToken cancellationToken)
     {
-        DateTimeOffset now = this._currentTimeSource.UtcNow();
+        DateTimeOffset now = this._timeProvider.GetUtcNow();
         IReadOnlyList<GitHubNotification> readyItems =
             await this._pendingNotificationStore.GetReadyItemsAsync(
                 now: now,
@@ -268,6 +267,7 @@ public sealed class GitHubPollingWorker : BackgroundService
             status: details.Status,
             priority: prPriority,
             isOnHold: prIsOnHold,
+            isUpToDate: details.IsUpToDate,
             cancellationToken: cancellationToken
         );
 

--- a/src/Credfeto.Dispatcher.GitHub/GitHubSetup.cs
+++ b/src/Credfeto.Dispatcher.GitHub/GitHubSetup.cs
@@ -6,6 +6,7 @@ using Credfeto.Dispatcher.GitHub.Configuration;
 using Credfeto.Dispatcher.GitHub.Interfaces;
 using Credfeto.Dispatcher.GitHub.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 
@@ -20,6 +21,8 @@ public static class GitHubSetup
 
     public static IServiceCollection AddGitHub(this IServiceCollection services)
     {
+        services.TryAddSingleton(TimeProvider.System);
+
         return services
             .AddSingleton<IValidateOptions<GitHubOptions>, GitHubOptionsValidator>()
             .AddHttpClient(name: "GitHub", configureClient: ConfigureGitHubHttpClient)

--- a/src/Credfeto.Dispatcher.GitHub/Models/ApiPullRequest.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Models/ApiPullRequest.cs
@@ -13,5 +13,6 @@ internal sealed record ApiPullRequest(
     [property: JsonPropertyName("html_url")] string HtmlUrl,
     [property: JsonPropertyName("assignees")] IReadOnlyList<ApiUser> Assignees,
     [property: JsonPropertyName("labels")] IReadOnlyList<ApiLabel> Labels,
-    [property: JsonPropertyName("head")] ApiPullRequestHead Head
+    [property: JsonPropertyName("head")] ApiPullRequestHead Head,
+    [property: JsonPropertyName("mergeable_state")] string? MergeableState
 );

--- a/src/Credfeto.Dispatcher.GitHub/Services/PullRequestDetailFetcher.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Services/PullRequestDetailFetcher.cs
@@ -19,6 +19,8 @@ public sealed class PullRequestDetailFetcher : IPullRequestDetailFetcher
     private const string ChangesRequestedState = "CHANGES_REQUESTED";
     private const string CiActivityReason = "ci_activity";
     private const int MaxBodyLength = 300;
+    private const string MergeableStateBehind = "behind";
+    private const string MergeableStateUnknown = "unknown";
 
     private readonly IHttpClientFactory _httpClientFactory;
 
@@ -88,7 +90,8 @@ public sealed class PullRequestDetailFetcher : IPullRequestDetailFetcher
             ReviewAuthor: reviewAuthor,
             ReviewUrl: reviewUrl,
             FailedRunName: failedRunName,
-            FailedRunUrl: failedRunUrl
+            FailedRunUrl: failedRunUrl,
+            IsUpToDate: DetermineIsUpToDate(pr.MergeableState)
         );
     }
 
@@ -214,6 +217,27 @@ public sealed class PullRequestDetailFetcher : IPullRequestDetailFetcher
         }
 
         return (failedRun.Name, new Uri(failedRun.HtmlUrl));
+    }
+
+    private static bool? DetermineIsUpToDate(string? mergeableState)
+    {
+        if (
+            mergeableState is null
+            || string.Equals(
+                a: mergeableState,
+                b: MergeableStateUnknown,
+                comparisonType: StringComparison.OrdinalIgnoreCase
+            )
+        )
+        {
+            return null;
+        }
+
+        return !string.Equals(
+            a: mergeableState,
+            b: MergeableStateBehind,
+            comparisonType: StringComparison.OrdinalIgnoreCase
+        );
     }
 
     private static string DetermineStatus(ApiPullRequest pr)

--- a/src/Credfeto.Dispatcher.GitHub/Services/WorkItemScanner.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Services/WorkItemScanner.cs
@@ -206,6 +206,7 @@ public sealed class WorkItemScanner : IWorkItemScanner
                     status: status,
                     priority: priority,
                     isOnHold: isOnHold,
+                    isUpToDate: null,
                     cancellationToken: cancellationToken
                 );
 

--- a/src/Credfeto.Dispatcher.Storage.Tests/Credfeto.Dispatcher.Storage.Tests.csproj
+++ b/src/Credfeto.Dispatcher.Storage.Tests/Credfeto.Dispatcher.Storage.Tests.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <PackageReference Include="FunFair.Test.Common" Version="6.2.22.2198" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Credfeto.Dispatcher.Storage.Tests/Services/NotificationStateTrackerTests.cs
+++ b/src/Credfeto.Dispatcher.Storage.Tests/Services/NotificationStateTrackerTests.cs
@@ -2,12 +2,11 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Credfeto.Date.Interfaces;
 using Credfeto.Dispatcher.GitHub.DataTypes;
 using Credfeto.Dispatcher.GitHub.Interfaces;
 using FunFair.Test.Common;
 using Microsoft.EntityFrameworkCore;
-using NSubstitute;
+using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
 namespace Credfeto.Dispatcher.Storage.Tests.Services;
@@ -30,7 +29,6 @@ public sealed class NotificationStateTrackerTests : LoggingFolderCleanupTestBase
     private const string OpenStatus = "Open";
     private const string ClosedStatus = "Closed";
 
-    private readonly ICurrentTimeSource _currentTimeSource;
     private readonly INotificationStateTracker _tracker;
 
     public NotificationStateTrackerTests(ITestOutputHelper output)
@@ -47,12 +45,11 @@ public sealed class NotificationStateTrackerTests : LoggingFolderCleanupTestBase
             ctx.Database.Migrate();
         }
 
-        this._currentTimeSource = GetSubstitute<ICurrentTimeSource>();
-        this._currentTimeSource.UtcNow().Returns(TestNow);
+        FakeTimeProvider timeProvider = new(startDateTime: TestNow);
 
         this._tracker = new NotificationStateTracker(
             new TestDbContextFactory(options),
-            this._currentTimeSource
+            timeProvider
         );
     }
 
@@ -94,6 +91,7 @@ public sealed class NotificationStateTrackerTests : LoggingFolderCleanupTestBase
             status: OpenStatus,
             priority: WorkPriority.Unknown,
             isOnHold: false,
+            isUpToDate: null,
             cancellationToken: this.CancellationToken()
         );
     }
@@ -107,6 +105,7 @@ public sealed class NotificationStateTrackerTests : LoggingFolderCleanupTestBase
             status: OpenStatus,
             priority: WorkPriority.Unknown,
             isOnHold: false,
+            isUpToDate: null,
             cancellationToken: this.CancellationToken()
         );
 
@@ -116,6 +115,7 @@ public sealed class NotificationStateTrackerTests : LoggingFolderCleanupTestBase
             status: ClosedStatus,
             priority: WorkPriority.Unknown,
             isOnHold: false,
+            isUpToDate: null,
             cancellationToken: this.CancellationToken()
         );
     }

--- a/src/Credfeto.Dispatcher.Storage.Tests/Services/NotificationStateTrackerTests.cs
+++ b/src/Credfeto.Dispatcher.Storage.Tests/Services/NotificationStateTrackerTests.cs
@@ -4,8 +4,8 @@ using System.Threading.Tasks;
 using Credfeto.Dispatcher.GitHub.DataTypes;
 using Credfeto.Dispatcher.GitHub.Interfaces;
 using FunFair.Test.Common;
+using FunFair.Test.Common.Mocks;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
 namespace Credfeto.Dispatcher.Storage.Tests.Services;
@@ -34,11 +34,9 @@ public sealed class NotificationStateTrackerTests : LoggingFolderCleanupTestBase
             ctx.Database.Migrate();
         }
 
-        FakeTimeProvider timeProvider = new(startDateTime: TimeSources.Past.UtcNowAsOffset);
-
         this._tracker = new NotificationStateTracker(
             new TestDbContextFactory(options),
-            timeProvider
+            MockDateTimeSources.Past
         );
     }
 

--- a/src/Credfeto.Dispatcher.Storage.Tests/Services/NotificationStateTrackerTests.cs
+++ b/src/Credfeto.Dispatcher.Storage.Tests/Services/NotificationStateTrackerTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,16 +12,6 @@ namespace Credfeto.Dispatcher.Storage.Tests.Services;
 
 public sealed class NotificationStateTrackerTests : LoggingFolderCleanupTestBase
 {
-    private static readonly DateTimeOffset TestNow = new(
-        year: 2025,
-        month: 1,
-        day: 1,
-        hour: 12,
-        minute: 0,
-        second: 0,
-        offset: TimeSpan.Zero
-    );
-
     private const string TestRepository = "test-owner/test-repo";
     private const int TestPullRequestNumber = 42;
     private const int TestIssueNumber = 7;
@@ -45,7 +34,7 @@ public sealed class NotificationStateTrackerTests : LoggingFolderCleanupTestBase
             ctx.Database.Migrate();
         }
 
-        FakeTimeProvider timeProvider = new(startDateTime: TestNow);
+        FakeTimeProvider timeProvider = new(startDateTime: TimeSources.Past.UtcNowAsOffset);
 
         this._tracker = new NotificationStateTracker(
             new TestDbContextFactory(options),

--- a/src/Credfeto.Dispatcher.Storage/DispatcherDbContext.cs
+++ b/src/Credfeto.Dispatcher.Storage/DispatcherDbContext.cs
@@ -34,6 +34,11 @@ public sealed class DispatcherDbContext : DbContext
         checkId: "IL2026",
         Justification = "EF Core fluent API lambda expressions compile to expression trees that internally use Expression.New(ConstructorInfo,...); the models and properties accessed are preserved by this explicit fluent configuration"
     )]
+    [SuppressMessage(
+        "Philips.CodeAnalysis.DuplicateCodeAnalyzer",
+        "PH2071:Duplicate shape found",
+        Justification = "Fluent API property configuration lines are structurally identical by design; each configures a different entity property."
+    )]
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<PollingStateEntity>().Property(e => e.Key).HasMaxLength(256);
@@ -49,6 +54,11 @@ public sealed class DispatcherDbContext : DbContext
 
         modelBuilder.Entity<PullRequestEntity>().Property(e => e.IsOnHold).HasColumnType("INTEGER");
 
+        modelBuilder
+            .Entity<PullRequestEntity>()
+            .Property(e => e.IsUpToDate)
+            .HasColumnType("INTEGER");
+
         modelBuilder.Entity<IssueEntity>().HasKey(e => new { e.Repository, e.Id });
 
         modelBuilder
@@ -61,6 +71,11 @@ public sealed class DispatcherDbContext : DbContext
 
         modelBuilder.Entity<IssueEntity>().Property(e => e.HasLinkedPr).HasColumnType("INTEGER");
 
+        ConfigureNotificationQueue(modelBuilder);
+    }
+
+    private static void ConfigureNotificationQueue(ModelBuilder modelBuilder)
+    {
         modelBuilder.Entity<NotificationQueueEntity>().HasKey(e => e.SubjectUrl);
 
         modelBuilder

--- a/src/Credfeto.Dispatcher.Storage/Entities/PullRequestEntity.cs
+++ b/src/Credfeto.Dispatcher.Storage/Entities/PullRequestEntity.cs
@@ -22,4 +22,6 @@ public sealed class PullRequestEntity : INotificationEntity
     public WorkPriority Priority { get; set; } = WorkPriority.Unknown;
 
     public bool IsOnHold { get; set; }
+
+    public bool? IsUpToDate { get; set; }
 }

--- a/src/Credfeto.Dispatcher.Storage/Migrations/AddIsUpToDateToPullRequests.cs
+++ b/src/Credfeto.Dispatcher.Storage/Migrations/AddIsUpToDateToPullRequests.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Credfeto.Dispatcher.Storage.Migrations;
+
+[DbContext(typeof(DispatcherDbContext))]
+[Migration("20260508000000_AddIsUpToDateToPullRequests")]
+public sealed partial class AddIsUpToDateToPullRequests : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<bool>(
+            name: "IsUpToDate",
+            table: "PullRequests",
+            type: "INTEGER",
+            nullable: true,
+            defaultValue: null
+        );
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(name: "IsUpToDate", table: "PullRequests");
+    }
+}

--- a/src/Credfeto.Dispatcher.Storage/Migrations/DispatcherDbContextModelSnapshot.cs
+++ b/src/Credfeto.Dispatcher.Storage/Migrations/DispatcherDbContextModelSnapshot.cs
@@ -49,6 +49,7 @@ internal sealed class DispatcherDbContextModelSnapshot : ModelSnapshot
                     new ValueConverter<WorkPriority, int>(v => (int)v, v => (WorkPriority)v)
                 );
             b.Property(e => e.IsOnHold).HasColumnType("INTEGER");
+            b.Property(e => e.IsUpToDate).HasColumnType("INTEGER");
         });
 
         modelBuilder.Entity<IssueEntity>(b =>

--- a/src/Credfeto.Dispatcher.Storage/NotificationStateTracker.cs
+++ b/src/Credfeto.Dispatcher.Storage/NotificationStateTracker.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
-using Credfeto.Date.Interfaces;
 using Credfeto.Dispatcher.GitHub.DataTypes;
 using Credfeto.Dispatcher.GitHub.Interfaces;
 using Credfeto.Dispatcher.Storage.Entities;
@@ -14,16 +13,16 @@ public sealed class NotificationStateTracker : INotificationStateTracker
 {
     private const string ClosedStatus = "Closed";
 
-    private readonly ICurrentTimeSource _currentTimeSource;
     private readonly IDbContextFactory<DispatcherDbContext> _dbContextFactory;
+    private readonly TimeProvider _timeProvider;
 
     public NotificationStateTracker(
         IDbContextFactory<DispatcherDbContext> dbContextFactory,
-        ICurrentTimeSource currentTimeSource
+        TimeProvider timeProvider
     )
     {
         this._dbContextFactory = dbContextFactory;
-        this._currentTimeSource = currentTimeSource;
+        this._timeProvider = timeProvider;
     }
 
     public Task<bool> ShouldSkipPullRequestAsync(
@@ -47,6 +46,7 @@ public sealed class NotificationStateTracker : INotificationStateTracker
         string status,
         WorkPriority priority,
         bool isOnHold,
+        bool? isUpToDate,
         CancellationToken cancellationToken
     )
     {
@@ -57,7 +57,7 @@ public sealed class NotificationStateTracker : INotificationStateTracker
             keyValues: [repository, pullRequestNumber],
             cancellationToken: cancellationToken
         );
-        DateTimeOffset now = this._currentTimeSource.UtcNow();
+        DateTimeOffset now = this._timeProvider.GetUtcNow();
 
         if (existing is null)
         {
@@ -68,6 +68,7 @@ public sealed class NotificationStateTracker : INotificationStateTracker
                     status: status,
                     priority: priority,
                     isOnHold: isOnHold,
+                    isUpToDate: isUpToDate,
                     now: now
                 )
             );
@@ -79,6 +80,7 @@ public sealed class NotificationStateTracker : INotificationStateTracker
                 status: status,
                 priority: priority,
                 isOnHold: isOnHold,
+                isUpToDate: isUpToDate,
                 now: now
             );
         }
@@ -118,7 +120,7 @@ public sealed class NotificationStateTracker : INotificationStateTracker
             keyValues: [repository, issueNumber],
             cancellationToken: cancellationToken
         );
-        DateTimeOffset now = this._currentTimeSource.UtcNow();
+        DateTimeOffset now = this._timeProvider.GetUtcNow();
 
         if (existing is null)
         {
@@ -164,6 +166,7 @@ public sealed class NotificationStateTracker : INotificationStateTracker
         string status,
         WorkPriority priority,
         bool isOnHold,
+        bool? isUpToDate,
         in DateTimeOffset now
     )
     {
@@ -174,6 +177,7 @@ public sealed class NotificationStateTracker : INotificationStateTracker
             Status = status,
             Priority = priority,
             IsOnHold = isOnHold,
+            IsUpToDate = isUpToDate,
             FirstSeen = now,
             LastUpdated = now,
             WhenClosed = IsClosedStatus(status) ? now : null,
@@ -209,6 +213,7 @@ public sealed class NotificationStateTracker : INotificationStateTracker
         string status,
         WorkPriority priority,
         bool isOnHold,
+        bool? isUpToDate,
         in DateTimeOffset now
     )
     {
@@ -216,6 +221,11 @@ public sealed class NotificationStateTracker : INotificationStateTracker
         entity.Priority = priority;
         entity.IsOnHold = isOnHold;
         entity.LastUpdated = now;
+
+        if (isUpToDate.HasValue)
+        {
+            entity.IsUpToDate = isUpToDate.Value;
+        }
 
         if (IsClosedStatus(status))
         {

--- a/src/Credfeto.Dispatcher.Storage/StorageSetup.cs
+++ b/src/Credfeto.Dispatcher.Storage/StorageSetup.cs
@@ -1,9 +1,11 @@
+using System;
 using System.IO;
 using Credfeto.Dispatcher.GitHub.Interfaces;
 using Credfeto.Dispatcher.Storage.Services;
 using Credfeto.Services.Startup.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace Credfeto.Dispatcher.Storage;
@@ -22,6 +24,8 @@ public static class StorageSetup
         Directory.CreateDirectory(dataPath);
 
         string dbPath = Path.Combine(dataPath, DatabaseFileName);
+
+        services.TryAddSingleton(TimeProvider.System);
 
         return services
             .AddDbContextFactory<DispatcherDbContext>(options =>

--- a/src/Credfeto.Dispatcher.Storage/WorkItemRepository.cs
+++ b/src/Credfeto.Dispatcher.Storage/WorkItemRepository.cs
@@ -40,13 +40,22 @@ public sealed class WorkItemRepository : IWorkItemRepository
                 PullRequestType,
                 e.Priority,
                 e.FirstSeen,
+                e.LastUpdated,
                 e.IsUpToDate
             ))
             .ToListAsync(cancellationToken);
 
         List<WorkItem> issues = await context
             .Issues.Where(e => e.Status != ClosedStatus && !e.IsOnHold && !e.HasLinkedPr)
-            .Select(e => new WorkItem(e.Repository, e.Id, IssueType, e.Priority, e.FirstSeen, null))
+            .Select(e => new WorkItem(
+                e.Repository,
+                e.Id,
+                IssueType,
+                e.Priority,
+                e.FirstSeen,
+                e.LastUpdated,
+                null
+            ))
             .ToListAsync(cancellationToken);
 
         List<WorkItem> combined = [.. pullRequests, .. issues];

--- a/src/Credfeto.Dispatcher.Storage/WorkItemRepository.cs
+++ b/src/Credfeto.Dispatcher.Storage/WorkItemRepository.cs
@@ -34,12 +34,19 @@ public sealed class WorkItemRepository : IWorkItemRepository
 
         List<WorkItem> pullRequests = await context
             .PullRequests.Where(e => e.Status != ClosedStatus && !e.IsOnHold)
-            .Select(e => new WorkItem(e.Repository, e.Id, PullRequestType, e.Priority, e.FirstSeen))
+            .Select(e => new WorkItem(
+                e.Repository,
+                e.Id,
+                PullRequestType,
+                e.Priority,
+                e.FirstSeen,
+                e.IsUpToDate
+            ))
             .ToListAsync(cancellationToken);
 
         List<WorkItem> issues = await context
             .Issues.Where(e => e.Status != ClosedStatus && !e.IsOnHold && !e.HasLinkedPr)
-            .Select(e => new WorkItem(e.Repository, e.Id, IssueType, e.Priority, e.FirstSeen))
+            .Select(e => new WorkItem(e.Repository, e.Id, IssueType, e.Priority, e.FirstSeen, null))
             .ToListAsync(cancellationToken);
 
         List<WorkItem> combined = [.. pullRequests, .. issues];


### PR DESCRIPTION
## Summary

- Adds `IsUpToDate` (`bool?`) to `PullRequestEntity`, `WorkItem`, and `INotificationStateTracker.UpdatePullRequestStateAsync` so consumers can decide whether to rebase a PR
- Reads `mergeable_state` from the GitHub individual PR endpoint: `null`/`unknown` → `null`, `behind` → `false`, anything else → `true`
- Adds EF Core migration `AddIsUpToDateToPullRequests` and updates model snapshot
- Migrates `NotificationStateTracker` and `GitHubPollingWorker` from deprecated `ICurrentTimeSource` to `System.TimeProvider` / `FakeTimeProvider`

Closes #39

## Test plan

- [ ] All 138 unit tests pass locally (0 failures)
- [ ] `IsUpToDate` is `true` when `mergeable_state` is `clean`, `has_hooks`, etc.
- [ ] `IsUpToDate` is `false` when `mergeable_state` is `behind`
- [ ] `IsUpToDate` is `null` when `mergeable_state` is `unknown` or absent (list endpoint)
- [ ] Database migration applies cleanly on a fresh database
- [ ] Existing PR records get `null` for `IsUpToDate` (nullable column, no default)