### PR TITLE
feat(#56): make LabelFilter and NoWorkFilter comparisons fuzzy and case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Store whether a pull request branch is up-to-date with its base in the database, exposed via WorkItem and the priorities endpoint so consumers can decide whether to rebase
 - LastUpdated field included in /priorities API response work items
 - smoke-test script (scripts/smoke-test.sh) and Dockerfile build-time gate to verify the trimmed binary starts and /priorities returns HTTP 200 before the image is finalized
+- Fuzzy case-insensitive label matching for LabelFilter and NoWorkFilter
 ### Fixed
 - EF Core change-tracking comparers trimmed away at publish time causing MissingMethodException at startup; preserve EF Core and Ben.Demystifier assemblies as trimmer roots
 - preserve EF Core migration types as trimmer roots to prevent missing-table errors at runtime on trimmed binaries

--- a/src/Credfeto.Dispatcher.GitHub.Tests/Services/WorkItemScannerTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/Services/WorkItemScannerTests.cs
@@ -125,6 +125,45 @@ public sealed class WorkItemScannerTests : TestBase
         }]
         """;
 
+    private const string PrWithAiWorkSpaceLabelJson = """
+        [{
+          "number": 7,
+          "title": "AI Work PR (space variant)",
+          "state": "open",
+          "draft": false,
+          "html_url": "https://github.com/owner/repo/pull/7",
+          "assignees": [],
+          "labels": [{"name": "AI Work"}],
+          "head": {"sha": "stu901"}
+        }]
+        """;
+
+    private const string PrWithAiWorkLowercaseLabelJson = """
+        [{
+          "number": 8,
+          "title": "AI Work PR (lowercase variant)",
+          "state": "open",
+          "draft": false,
+          "html_url": "https://github.com/owner/repo/pull/8",
+          "assignees": [],
+          "labels": [{"name": "ai work"}],
+          "head": {"sha": "vwx234"}
+        }]
+        """;
+
+    private const string PrWithOnHoldSpaceLabelJson = """
+        [{
+          "number": 9,
+          "title": "On-hold PR (space variant)",
+          "state": "open",
+          "draft": false,
+          "html_url": "https://github.com/owner/repo/pull/9",
+          "assignees": [],
+          "labels": [{"name": "on hold"}],
+          "head": {"sha": "yza567"}
+        }]
+        """;
+
     private const string PrPage1Json = """
         [{
           "number": 10,
@@ -566,6 +605,96 @@ public sealed class WorkItemScannerTests : TestBase
                 status: Arg.Any<string>(),
                 priority: Arg.Any<WorkPriority>(),
                 isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task ScanAsync_WithSpaceVariantLabelFilter_CallsUpdateAsync()
+    {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
+        using HttpClient prClient = CreateClient(HttpStatusCode.OK, PrWithAiWorkSpaceLabelJson);
+        using HttpClient issueClient = CreateClient(HttpStatusCode.OK, EmptyJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
+
+        GitHubOptions options = new()
+        {
+            Filter = new GitHubFilterOptions { LabelFilter = ["AI-Work"] },
+        };
+
+        WorkItemScanner scanner = this.CreateScanner(options);
+
+        await scanner.ScanAsync(this.CancellationToken());
+
+        await this
+            ._notificationStateTracker.Received(1)
+            .UpdatePullRequestStateAsync(
+                repository: Repo,
+                pullRequestNumber: 7,
+                status: Arg.Any<string>(),
+                priority: Arg.Any<WorkPriority>(),
+                isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task ScanAsync_WithLowercaseVariantLabelFilter_CallsUpdateAsync()
+    {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
+        using HttpClient prClient = CreateClient(HttpStatusCode.OK, PrWithAiWorkLowercaseLabelJson);
+        using HttpClient issueClient = CreateClient(HttpStatusCode.OK, EmptyJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
+
+        GitHubOptions options = new()
+        {
+            Filter = new GitHubFilterOptions { LabelFilter = ["AI-Work"] },
+        };
+
+        WorkItemScanner scanner = this.CreateScanner(options);
+
+        await scanner.ScanAsync(this.CancellationToken());
+
+        await this
+            ._notificationStateTracker.Received(1)
+            .UpdatePullRequestStateAsync(
+                repository: Repo,
+                pullRequestNumber: 8,
+                status: Arg.Any<string>(),
+                priority: Arg.Any<WorkPriority>(),
+                isOnHold: Arg.Any<bool>(),
+                isUpToDate: Arg.Any<bool?>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task ScanAsync_WithSpaceVariantOnHoldLabel_CallsUpdateWithIsOnHoldTrueAsync()
+    {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
+        using HttpClient prClient = CreateClient(HttpStatusCode.OK, PrWithOnHoldSpaceLabelJson);
+        using HttpClient issueClient = CreateClient(HttpStatusCode.OK, EmptyJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
+
+        GitHubOptions options = new()
+        {
+            Filter = new GitHubFilterOptions { NoWorkFilter = ["on-hold"] },
+        };
+
+        WorkItemScanner scanner = this.CreateScanner(options);
+
+        await scanner.ScanAsync(this.CancellationToken());
+
+        await this
+            ._notificationStateTracker.Received(1)
+            .UpdatePullRequestStateAsync(
+                repository: Repo,
+                pullRequestNumber: 9,
+                status: Arg.Any<string>(),
+                priority: Arg.Any<WorkPriority>(),
+                isOnHold: true,
                 isUpToDate: Arg.Any<bool?>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );

--- a/src/Credfeto.Dispatcher.GitHub/LabelParser.cs
+++ b/src/Credfeto.Dispatcher.GitHub/LabelParser.cs
@@ -37,14 +37,35 @@ internal static class LabelParser
 
     public static bool IsOnHold(IReadOnlyList<string> labels, IReadOnlyList<string> noWorkFilter)
     {
-        return labels.Any(label =>
-            noWorkFilter.Any(filter =>
-                string.Equals(
-                    a: label,
-                    b: filter,
-                    comparisonType: StringComparison.OrdinalIgnoreCase
-                )
-            )
+        return labels.Any(label => noWorkFilter.Any(filter => FuzzyEquals(label, filter)));
+    }
+
+    internal static bool FuzzyEquals(string a, string b)
+    {
+        return string.Equals(
+            a: Normalize(a),
+            b: Normalize(b),
+            comparisonType: StringComparison.OrdinalIgnoreCase
         );
+    }
+
+    private static string Normalize(string value)
+    {
+        return value
+            .Replace(
+                oldValue: "-",
+                newValue: string.Empty,
+                comparisonType: StringComparison.Ordinal
+            )
+            .Replace(
+                oldValue: " ",
+                newValue: string.Empty,
+                comparisonType: StringComparison.Ordinal
+            )
+            .Replace(
+                oldValue: "_",
+                newValue: string.Empty,
+                comparisonType: StringComparison.Ordinal
+            );
     }
 }

--- a/src/Credfeto.Dispatcher.GitHub/Services/WorkItemScanner.cs
+++ b/src/Credfeto.Dispatcher.GitHub/Services/WorkItemScanner.cs
@@ -295,13 +295,7 @@ public sealed class WorkItemScanner : IWorkItemScanner
         }
 
         return labelNames.Any(label =>
-            this._options.Filter.LabelFilter.Any(filter =>
-                string.Equals(
-                    a: label,
-                    b: filter,
-                    comparisonType: StringComparison.OrdinalIgnoreCase
-                )
-            )
+            this._options.Filter.LabelFilter.Any(filter => LabelParser.FuzzyEquals(label, filter))
         );
     }
 


### PR DESCRIPTION
Closes #56

## Changes

- Added `FuzzyEquals` and `Normalize` helpers to `LabelParser`
- `Normalize` strips dashes, spaces, and underscores before comparison
- Updated `LabelParser.IsOnHold` to use `FuzzyEquals`
- Updated `WorkItemScanner.PassesLabelFilter` to use `LabelParser.FuzzyEquals`
- Added three new test cases covering space-separated and lowercase label variants

## Examples

With filter configured as `["AI-Work"]`, all of these now match:
- `AI-Work` (exact, as before)
- `AI Work` (space instead of dash)
- `ai work` (lowercase with space)
- `aI-wOrk` (mixed case with dash)

Same fuzzy logic applies to `NoWorkFilter` (e.g. `on hold` matches `on-hold`).