### PR TITLE
refactor: Security label now ranked higher priority than Urgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Simplified INotificationStateTracker API to accept GitHubNotification and PullRequestDetails/IssueDetails objects instead of individual scalar parameters
 - INotificationStateTracker: changed Task/Task<bool> return types to ValueTask/ValueTask<bool>, renamed methods to overloads
 - Structured WorkItem fields: LinkedPrNumbers as ImmutableArray<int>, ReviewDecision as enum, FailedCheckNames as ImmutableArray<string>, added FailedCheckSha
+- Security label now has higher priority than Urgent in issue priority ordering
 ### Deprecated
 ### Removed
 - Removed IsUpToDate field from WorkItem and PullRequestDetails as it was never populated in production

--- a/src/Credfeto.Dispatcher.GitHub.DataTypes/WorkPriority.cs
+++ b/src/Credfeto.Dispatcher.GitHub.DataTypes/WorkPriority.cs
@@ -7,4 +7,5 @@ public enum WorkPriority
     Medium = 2,
     High = 3,
     Urgent = 4,
+    Security = 5,
 }

--- a/src/Credfeto.Dispatcher.GitHub.Tests/Services/WorkItemScannerTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/Services/WorkItemScannerTests.cs
@@ -86,6 +86,19 @@ public sealed class WorkItemScannerTests : TestBase
         }]
         """;
 
+    private const string PrWithSecurityLabelJson = """
+        [{
+          "number": 9,
+          "title": "Security PR",
+          "state": "open",
+          "draft": false,
+          "html_url": "https://github.com/owner/repo/pull/9",
+          "assignees": [],
+          "labels": [{"name": "Security"}],
+          "head": {"sha": "vwx234"}
+        }]
+        """;
+
     private const string PrWithOnHoldLabelJson = """
         [{
           "number": 4,
@@ -495,6 +508,29 @@ public sealed class WorkItemScannerTests : TestBase
                 notification: Arg.Any<GitHubNotification>(),
                 details: Arg.Is<PullRequestDetails>(d => d.Number == 3),
                 priority: WorkPriority.Urgent,
+                isOnHold: Arg.Any<bool>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    public async Task ScanAsync_WithSecurityPriorityLabel_CallsUpdateWithSecurityPriorityAsync()
+    {
+        using HttpClient repoClient = CreateClient(HttpStatusCode.OK, UserReposJson);
+        using HttpClient prClient = CreateClient(HttpStatusCode.OK, PrWithSecurityLabelJson);
+        using HttpClient issueClient = CreateClient(HttpStatusCode.OK, EmptyJson);
+        this._httpClientFactory.CreateClient("GitHub").Returns(repoClient, prClient, issueClient);
+
+        WorkItemScanner scanner = this.CreateScanner();
+
+        await scanner.ScanAsync(this.CancellationToken());
+
+        await this
+            ._notificationStateTracker.Received(1)
+            .UpdateStateAsync(
+                notification: Arg.Any<GitHubNotification>(),
+                details: Arg.Is<PullRequestDetails>(d => d.Number == 9),
+                priority: WorkPriority.Security,
                 isOnHold: Arg.Any<bool>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             );

--- a/src/Credfeto.Dispatcher.GitHub/LabelParser.cs
+++ b/src/Credfeto.Dispatcher.GitHub/LabelParser.cs
@@ -11,6 +11,16 @@ internal static class LabelParser
     {
         foreach (string label in labels)
         {
+            if (
+                label.Contains(
+                    value: "security",
+                    comparisonType: StringComparison.OrdinalIgnoreCase
+                )
+            )
+            {
+                return WorkPriority.Security;
+            }
+
             if (label.Contains(value: "urgent", comparisonType: StringComparison.OrdinalIgnoreCase))
             {
                 return WorkPriority.Urgent;


### PR DESCRIPTION
## Summary

- Adds `Security = 5` to `WorkPriority` enum (above `Urgent = 4`)
- Updates `LabelParser.ParsePriority()` to return `WorkPriority.Security` when a label contains "security" — checked before "urgent"
- Adds test `ScanAsync_WithSecurityPriorityLabel_CallsUpdateWithSecurityPriorityAsync` to `WorkItemScannerTests`

Closes #79