### PR TITLE
feat: expose freshness metadata (as_of, lag_seconds) on /priorities response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Persist and return comment count, review decision, and failed CI check details for pull requests
 - Include stuck dependabot PRs in /priorities endpoint at Security priority after configurable timeout (default 3 hours)
 - Polling for modified issues that contain mentions of the configured user
+- Freshness metadata (as_of, lag_seconds) on /priorities response so consumers can detect stale snapshots
 ### Fixed
 - EF Core change-tracking comparers trimmed away at publish time causing MissingMethodException at startup; preserve EF Core and Ben.Demystifier assemblies as trimmer roots
 - preserve EF Core migration types as trimmer roots to prevent missing-table errors at runtime on trimmed binaries

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Because it uses only the GitHub REST Notifications API with a personal access to
 
 ## Architecture
 
-```
+```text
 Credfeto.Dispatcher.Server          - .NET Generic Host entry point
 Credfeto.Dispatcher.GitHub          - GitHub Notifications API polling + ETag state
 Credfeto.Dispatcher.GitHub.Interfaces - IGitHubNotificationPoller, INotificationFilter
@@ -53,9 +53,52 @@ Set the following in `appsettings.json` or environment variables:
 }
 ```
 
+## API
+
+### `GET /priorities`
+
+Returns the current prioritised work item list with freshness metadata.
+
+```json
+{
+  "as_of": "2026-05-13T14:32:18Z",
+  "lag_seconds": 47,
+  "priorities": [
+    {
+      "repository": "owner/repo",
+      "id": 123,
+      "itemType": "PullRequest",
+      "priority": "Urgent",
+      "firstSeen": "2026-05-10T09:00:00Z",
+      "lastUpdated": "2026-05-13T14:31:31Z",
+      "status": "Open",
+      "whenClosed": null,
+      "isOnHold": false,
+      "linkedPrNumbers": [],
+      "commentCount": 4,
+      "reviewDecision": "Approved",
+      "failedCheckCount": 0,
+      "failedCheckNames": [],
+      "failedCheckSha": null,
+      "author": "dependabot[bot]"
+    }
+  ]
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `as_of` | ISO-8601 UTC | Timestamp of the most recent ingest that contributed to this snapshot |
+| `lag_seconds` | integer | `now − as_of` in whole seconds; higher values indicate a staler snapshot |
+| `priorities` | array | Ordered work items (PRs before issues; by owner, repo, priority, age) |
+
+### `GET /ping`
+
+Lightweight health check — returns `{"value":"Pong!"}` without touching the database.
+
 ## Running locally
 
-1. Create a GitHub personal access token with `notifications` scope at https://github.com/settings/tokens
+1. Create a GitHub personal access token with `notifications` scope at [github.com/settings/tokens](https://github.com/settings/tokens)
 2. Create a Discord incoming webhook in your server's channel settings (Edit Channel → Integrations → Webhooks)
 3. Configure `appsettings-local.json` (gitignored) with your tokens
 4. Run `dotnet run --project src/Credfeto.Dispatcher.Server`

--- a/src/Credfeto.Dispatcher.GitHub.DataTypes/PrioritiesResponse.cs
+++ b/src/Credfeto.Dispatcher.GitHub.DataTypes/PrioritiesResponse.cs
@@ -1,0 +1,8 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Credfeto.Dispatcher.GitHub.DataTypes;
+
+[DebuggerDisplay("AsOf: {AsOf}, LagSeconds: {LagSeconds}, Count: {Priorities.Count}")]
+public sealed record PrioritiesResponse(IReadOnlyList<WorkItem> Priorities, DateTimeOffset AsOf, long LagSeconds);

--- a/src/Credfeto.Dispatcher.GitHub.Interfaces/IWorkItemRepository.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Interfaces/IWorkItemRepository.cs
@@ -8,7 +8,7 @@ namespace Credfeto.Dispatcher.GitHub.Interfaces;
 
 public interface IWorkItemRepository
 {
-    Task<IReadOnlyList<WorkItem>> GetPrioritisedWorkItemsAsync(
+    Task<PrioritiesResponse> GetPrioritisedWorkItemsAsync(
         IReadOnlyList<string> owners,
         IReadOnlyList<string> repos,
         TimeSpan stuckDependabotTimeout,

--- a/src/Credfeto.Dispatcher.Server/AppJsonContexts.cs
+++ b/src/Credfeto.Dispatcher.Server/AppJsonContexts.cs
@@ -1,10 +1,9 @@
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Credfeto.Dispatcher.GitHub.DataTypes;
 
 namespace Credfeto.Dispatcher.Server;
 
-[JsonSerializable(typeof(IReadOnlyList<WorkItem>))]
+[JsonSerializable(typeof(PrioritiesResponse))]
 [JsonSerializable(typeof(WorkItem))]
 [JsonSerializable(typeof(PongDto))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]

--- a/src/Credfeto.Dispatcher.Server/Endpoints.WorkItems.cs
+++ b/src/Credfeto.Dispatcher.Server/Endpoints.WorkItems.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Credfeto.Dispatcher.GitHub.DataTypes;
@@ -26,13 +25,13 @@ internal static partial class Endpoints
     )
     {
         PrioritiesOptions config = options.Value;
-        IReadOnlyList<WorkItem> items = await workItemRepository.GetPrioritisedWorkItemsAsync(
+        PrioritiesResponse response = await workItemRepository.GetPrioritisedWorkItemsAsync(
             owners: config.Owners,
             repos: config.Repos,
             stuckDependabotTimeout: TimeSpan.FromHours(config.StuckDependabotTimeoutHours),
             cancellationToken: cancellationToken
         );
 
-        return Results.Ok(items);
+        return Results.Ok(response);
     }
 }

--- a/src/Credfeto.Dispatcher.Storage.Tests/Services/WorkItemRepositoryTests.cs
+++ b/src/Credfeto.Dispatcher.Storage.Tests/Services/WorkItemRepositoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Credfeto.Dispatcher.GitHub.DataTypes;
@@ -522,6 +523,42 @@ public sealed class WorkItemRepositoryTests : TestBase, IAsyncLifetime
         Assert.Equal(expected: "dependabot[bot]", actual: single.Author);
     }
 
+    [Fact]
+    public async Task AsOf_IsMaxLastUpdatedAcrossAllItemsAsync()
+    {
+        DateTimeOffset older = BaseTime;
+        DateTimeOffset newer = BaseTime.AddMinutes(5);
+        this._seedContext.PullRequests.Add(CreatePr("owner/repo", id: 1, lastUpdated: older));
+        this._seedContext.Issues.Add(CreateIssue("owner/repo", id: 2, lastUpdated: newer));
+        await this._seedContext.SaveChangesAsync(this.CancellationToken());
+
+        PrioritiesResponse response = await this.GetResponseAsync(owners: [], repos: []);
+
+        Assert.Equal(expected: newer, actual: response.AsOf);
+    }
+
+    [Fact]
+    public async Task LagSeconds_IsNowMinusAsOfInWholeSecondsAsync()
+    {
+        DateTimeOffset lastUpdated = BaseTime;
+        this._timeProvider.SetUtcNow(BaseTime.AddSeconds(47));
+        this._seedContext.PullRequests.Add(CreatePr("owner/repo", id: 1, lastUpdated: lastUpdated));
+        await this._seedContext.SaveChangesAsync(this.CancellationToken());
+
+        PrioritiesResponse response = await this.GetResponseAsync(owners: [], repos: []);
+
+        Assert.Equal(expected: 47L, actual: response.LagSeconds);
+    }
+
+    [Fact]
+    public async Task AsOf_IsNowWhenNoItemsExistAsync()
+    {
+        PrioritiesResponse response = await this.GetResponseAsync(owners: [], repos: []);
+
+        Assert.Equal(expected: BaseTime, actual: response.AsOf);
+        Assert.Equal(expected: 0L, actual: response.LagSeconds);
+    }
+
     private async Task SeedIssuePrioritiesAsync()
     {
         await this._seedContext.Issues.AddRangeAsync(
@@ -534,7 +571,22 @@ public sealed class WorkItemRepositoryTests : TestBase, IAsyncLifetime
         await this._seedContext.SaveChangesAsync(this.CancellationToken());
     }
 
-    private Task<IReadOnlyList<WorkItem>> GetItemsAsync(
+    private async Task<IReadOnlyList<WorkItem>> GetItemsAsync(
+        IReadOnlyList<string> owners,
+        IReadOnlyList<string> repos,
+        TimeSpan stuckDependabotTimeout = default
+    )
+    {
+        PrioritiesResponse response = await this.GetResponseAsync(
+            owners: owners,
+            repos: repos,
+            stuckDependabotTimeout: stuckDependabotTimeout
+        );
+
+        return response.Priorities;
+    }
+
+    private Task<PrioritiesResponse> GetResponseAsync(
         IReadOnlyList<string> owners,
         IReadOnlyList<string> repos,
         in TimeSpan stuckDependabotTimeout = default
@@ -553,6 +605,7 @@ public sealed class WorkItemRepositoryTests : TestBase, IAsyncLifetime
         int id,
         string status = "Open",
         DateTimeOffset? firstSeen = null,
+        DateTimeOffset? lastUpdated = null,
         DateTimeOffset? whenClosed = null,
         int commentCount = 0,
         string? reviewDecision = null,
@@ -568,7 +621,7 @@ public sealed class WorkItemRepositoryTests : TestBase, IAsyncLifetime
             Id = id,
             Status = status,
             FirstSeen = firstSeen ?? BaseTime,
-            LastUpdated = BaseTime,
+            LastUpdated = lastUpdated ?? BaseTime,
             WhenClosed = whenClosed,
             CommentCount = commentCount,
             ReviewDecision = reviewDecision,
@@ -585,7 +638,8 @@ public sealed class WorkItemRepositoryTests : TestBase, IAsyncLifetime
         WorkPriority priority = WorkPriority.Unknown,
         bool isOnHold = false,
         int? linkedPrNumber = null,
-        DateTimeOffset? firstSeen = null
+        DateTimeOffset? firstSeen = null,
+        DateTimeOffset? lastUpdated = null
     )
     {
         return new IssueEntity
@@ -597,7 +651,7 @@ public sealed class WorkItemRepositoryTests : TestBase, IAsyncLifetime
             IsOnHold = isOnHold,
             LinkedPrNumber = linkedPrNumber,
             FirstSeen = firstSeen ?? BaseTime,
-            LastUpdated = BaseTime,
+            LastUpdated = lastUpdated ?? BaseTime,
         };
     }
 

--- a/src/Credfeto.Dispatcher.Storage/WorkItemRepository.cs
+++ b/src/Credfeto.Dispatcher.Storage/WorkItemRepository.cs
@@ -27,7 +27,7 @@ public sealed class WorkItemRepository : IWorkItemRepository
         this._timeProvider = timeProvider;
     }
 
-    public async Task<IReadOnlyList<WorkItem>> GetPrioritisedWorkItemsAsync(
+    public async Task<PrioritiesResponse> GetPrioritisedWorkItemsAsync(
         IReadOnlyList<string> owners,
         IReadOnlyList<string> repos,
         TimeSpan stuckDependabotTimeout,
@@ -54,7 +54,7 @@ public sealed class WorkItemRepository : IWorkItemRepository
 
         List<WorkItem> combined = Deduplicate([.. pullRequests, .. issues]);
 
-        return
+        IReadOnlyList<WorkItem> ordered =
         [
             .. combined
                 .OrderBy(w => FindIndex(owners, GetOwner(w.Repository)))
@@ -65,6 +65,11 @@ public sealed class WorkItemRepository : IWorkItemRepository
                 .ThenByDescending(w => (int)w.Priority)
                 .ThenBy(w => w.FirstSeen),
         ];
+
+        DateTimeOffset asOf = combined.Count > 0 ? combined.Max(w => w.LastUpdated) : now;
+        long lagSeconds = Math.Max(0, (long)(now - asOf).TotalSeconds);
+
+        return new PrioritiesResponse(Priorities: ordered, AsOf: asOf, LagSeconds: lagSeconds);
     }
 
     private static List<WorkItem> Deduplicate(IReadOnlyList<WorkItem> items)


### PR DESCRIPTION
## Summary

- Wraps the bare `WorkItem[]` in a `PrioritiesResponse` envelope with two new top-level fields
- `as_of` — `DateTimeOffset` of the most recent `LastUpdated` across all returned items (server-computed)
- `lag_seconds` — `Math.Max(0, (long)(now − as_of).TotalSeconds)` so clients can detect stale snapshots without clock dependency
- Existing `priorities` array is unchanged (additive, non-breaking shape change)
- README updated with `/priorities` response schema and field descriptions
- 3 new repository tests assert freshness fields: `AsOf_IsMaxLastUpdated`, `LagSeconds_IsNowMinusAsOf`, `AsOf_IsNowWhenNoItemsExist`

Closes #85

## Test plan

- [ ] All 175 tests pass (`dotnet test`)
- [ ] `as_of` equals the highest `LastUpdated` across returned items
- [ ] `lag_seconds` equals `(now − as_of)` in whole seconds
- [ ] Empty DB: `as_of = now`, `lag_seconds = 0`