### PR TITLE
fix: suppress Polly telemetry noise and fix Task.Delay cancellation on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Link issues to open pull requests from PR-linked references so /priorities returns the PR instead of the linked issue
 - Notification poller stuck on empty ETag now forces a fresh poll; scan interval reduced to 30 minutes; DB timestamp columns added to PollingStates, PullRequests, and Issues; stored procedures now own their own timestamps via GETUTCDATE()
 - Issues_LinkPullRequest stored procedure now computes @now internally, fixing runtime error when linking issues to pull requests
+- Suppress Polly HTTP resilience telemetry noise and fix Task.Delay unhandled cancellation in background services during shutdown
 ### Changed
 - Dependencies - Updated Credfeto.Version.Information.Generator to 1.0.124.1183
 - Dependencies - Updated FunFair.CodeAnalysis to 7.1.41.1934

--- a/src/Credfeto.Dispatcher.GitHub.Tests/BackgroundServices/RepoEventPollerServiceTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/BackgroundServices/RepoEventPollerServiceTests.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.Dispatcher.GitHub.BackgroundServices;
+using Credfeto.Dispatcher.GitHub.Configuration;
+using Credfeto.Dispatcher.GitHub.Interfaces;
+using FunFair.Test.Common;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Credfeto.Dispatcher.GitHub.Tests.BackgroundServices;
+
+public sealed class RepoEventPollerServiceTests : TestBase
+{
+    private RepoEventPollerService CreateService(IRepoEventPoller poller, GitHubOptions? options = null)
+    {
+        return new RepoEventPollerService(
+            poller: poller,
+            options: Options.Create(options ?? new GitHubOptions()),
+            logger: this.GetTypedLogger<RepoEventPollerService>()
+        );
+    }
+
+    [Fact]
+    public async Task CallsPollerOnStartupAsync()
+    {
+        TaskCompletionSource pollStarted = new();
+        FakePoller poller = new(onPoll: () => pollStarted.TrySetResult());
+
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        using RepoEventPollerService service = this.CreateService(poller);
+        await service.StartAsync(token);
+        await pollStarted.Task.WaitAsync(timeout: TimeSpan.FromSeconds(5), cancellationToken: token);
+        await service.StopAsync(token);
+
+        Assert.True(poller.PollCount >= 1, "Expected poller to have been called at least once");
+    }
+
+    [Fact]
+    public async Task StopsGracefullyWhenPollerThrowsOperationCanceledExceptionAsync()
+    {
+        TaskCompletionSource pollCalled = new();
+        FakePoller poller = new(onPoll: () => pollCalled.TrySetResult(), exception: new OperationCanceledException());
+
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        using RepoEventPollerService service = this.CreateService(poller);
+        await service.StartAsync(token);
+        await pollCalled.Task.WaitAsync(timeout: TimeSpan.FromSeconds(5), cancellationToken: token);
+        await service.StopAsync(token);
+
+        Assert.True(poller.PollCount >= 1, "Expected poller to have been called at least once");
+    }
+
+    [Fact]
+    public async Task CallsPollerWhenPollIntervalSecondsIsZeroAsync()
+    {
+        TaskCompletionSource pollStarted = new();
+        FakePoller poller = new(onPoll: () => pollStarted.TrySetResult());
+
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        using RepoEventPollerService service = this.CreateService(
+            poller,
+            new GitHubOptions { PollIntervalSeconds = 0 }
+        );
+        await service.StartAsync(token);
+        await pollStarted.Task.WaitAsync(timeout: TimeSpan.FromSeconds(5), cancellationToken: token);
+        await service.StopAsync(token);
+
+        Assert.True(poller.PollCount >= 1, "Expected poller to have been called at least once");
+    }
+
+    [Fact]
+    public async Task HandlesExceptionFromPollerWithoutCrashingAsync()
+    {
+        TaskCompletionSource exceptionThrown = new();
+        FakePoller poller = new(
+            onPoll: () => exceptionThrown.TrySetResult(),
+            exception: new InvalidOperationException("Test poll failure")
+        );
+
+        CancellationToken token = TestContext.Current.CancellationToken;
+
+        using RepoEventPollerService service = this.CreateService(poller);
+        await service.StartAsync(token);
+        await exceptionThrown.Task.WaitAsync(timeout: TimeSpan.FromSeconds(5), cancellationToken: token);
+        await service.StopAsync(token);
+
+        Assert.True(poller.PollCount >= 1, "Expected poller to have been called at least once");
+    }
+
+    private sealed class FakePoller : IRepoEventPoller
+    {
+        private readonly Exception? _exception;
+        private readonly Action _onPoll;
+        private int _pollCount;
+
+        public FakePoller(Action onPoll, Exception? exception = null)
+        {
+            this._onPoll = onPoll;
+            this._exception = exception;
+        }
+
+        public int PollCount => this._pollCount;
+
+        public ValueTask PollAsync(CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref this._pollCount);
+            this._onPoll();
+
+            if (this._exception is not null)
+            {
+                return ValueTask.FromException(this._exception);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Credfeto.Dispatcher.GitHub.Tests/BackgroundServices/RepoEventPollerServiceTests.cs
+++ b/src/Credfeto.Dispatcher.GitHub.Tests/BackgroundServices/RepoEventPollerServiceTests.cs
@@ -32,6 +32,7 @@ public sealed class RepoEventPollerServiceTests : TestBase
         using RepoEventPollerService service = this.CreateService(poller);
         await service.StartAsync(token);
         await pollStarted.Task.WaitAsync(timeout: TimeSpan.FromSeconds(5), cancellationToken: token);
+        await Task.Delay(millisecondsDelay: 200, cancellationToken: token);
         await service.StopAsync(token);
 
         Assert.True(poller.PollCount >= 1, "Expected poller to have been called at least once");
@@ -50,7 +51,10 @@ public sealed class RepoEventPollerServiceTests : TestBase
         await pollCalled.Task.WaitAsync(timeout: TimeSpan.FromSeconds(5), cancellationToken: token);
         await service.StopAsync(token);
 
-        Assert.True(poller.PollCount >= 1, "Expected poller to have been called at least once");
+        Assert.True(
+            poller.PollCount == 1,
+            "Expected poller to have been called exactly once before stopping due to OperationCanceledException"
+        );
     }
 
     [Fact]

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/GitHubPollingWorker.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/GitHubPollingWorker.cs
@@ -70,7 +70,14 @@ public sealed class GitHubPollingWorker : BackgroundService
 
             int pollIntervalSeconds = this._options.PollIntervalSeconds > 0 ? this._options.PollIntervalSeconds : 60;
 
-            await Task.Delay(millisecondsDelay: pollIntervalSeconds * 1000, cancellationToken: stoppingToken);
+            try
+            {
+                await Task.Delay(millisecondsDelay: pollIntervalSeconds * 1000, cancellationToken: stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
         }
 
         this._logger.LogWorkerStopping();

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/RepoEventPollerService.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/RepoEventPollerService.cs
@@ -48,7 +48,14 @@ public sealed class RepoEventPollerService : BackgroundService
 
             int pollIntervalSeconds = this._options.PollIntervalSeconds > 0 ? this._options.PollIntervalSeconds : 60;
 
-            await Task.Delay(millisecondsDelay: pollIntervalSeconds * 1000, cancellationToken: stoppingToken);
+            try
+            {
+                await Task.Delay(millisecondsDelay: pollIntervalSeconds * 1000, cancellationToken: stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
         }
 
         this._logger.LogEventPollerStopping();

--- a/src/Credfeto.Dispatcher.GitHub/BackgroundServices/WorkItemScannerService.cs
+++ b/src/Credfeto.Dispatcher.GitHub/BackgroundServices/WorkItemScannerService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Credfeto.Dispatcher.GitHub.BackgroundServices.LoggingExtensions;
@@ -47,14 +47,16 @@ public sealed class WorkItemScannerService : BackgroundService
             }
 
             int intervalSeconds =
-                this._scanOptions.ScanIntervalSeconds > 0
-                    ? this._scanOptions.ScanIntervalSeconds
-                    : 1800;
+                this._scanOptions.ScanIntervalSeconds > 0 ? this._scanOptions.ScanIntervalSeconds : 1800;
 
-            await Task.Delay(
-                millisecondsDelay: intervalSeconds * 1000,
-                cancellationToken: stoppingToken
-            );
+            try
+            {
+                await Task.Delay(millisecondsDelay: intervalSeconds * 1000, cancellationToken: stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
         }
 
         this._logger.LogScannerStopping();

--- a/src/Credfeto.Dispatcher.Server/appsettings.json
+++ b/src/Credfeto.Dispatcher.Server/appsettings.json
@@ -3,7 +3,8 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Polly": "Warning"
     }
   },
   "Database": {


### PR DESCRIPTION
## Summary

- Add `"Polly": "Warning"` log level override to suppress INFO-level Polly resilience telemetry that includes exception stack traces during graceful shutdown
- Fix bare `await Task.Delay(...)` calls in background services (`RepoEventPollerService`, `WorkItemScannerService`, `GitHubPollingWorker`) so that shutdown during the delay period still logs the stopping message
- Add `RepoEventPollerServiceTests` covering startup and shutdown scenarios

## Test plan

- [ ] Build passes
- [ ] All tests pass
- [ ] Manually verify shutdown no longer shows exception stack trace in logs
- [ ] Verify `"*pollerStopping"` log is always emitted on shutdown

Closes #137