### PR TITLE
feat: add X-Server response header containing the server hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Added X-Version response header middleware to expose server version on all HTTP responses
 - Configurable rules for upgrading bot-authored pull requests to a baseline and/or security priority based on author login, branch prefix, and inactivity timeout
 - DefaultPriority property on BotPrRule assigns a baseline priority on first rule match, with escalation to a higher priority after the configured timeout
+- Add X-Server response header containing the hostname of the machine serving the request
 ### Fixed
 - EF Core change-tracking comparers trimmed away at publish time causing MissingMethodException at startup; preserve EF Core and Ben.Demystifier assemblies as trimmer roots
 - preserve EF Core migration types as trimmer roots to prevent missing-table errors at runtime on trimmed binaries

--- a/src/Credfeto.Dispatcher.Server/Helpers/ServerStartup.cs
+++ b/src/Credfeto.Dispatcher.Server/Helpers/ServerStartup.cs
@@ -8,6 +8,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Credfeto.Dispatcher.GitHub;
 using Credfeto.Dispatcher.GitHub.Configuration;
+using Credfeto.Dispatcher.Shared;
+using Credfeto.Dispatcher.Shared.Middleware;
 using Credfeto.Dispatcher.Storage;
 using Credfeto.Dispatcher.Storage.Configuration;
 using Credfeto.Random;
@@ -70,6 +72,7 @@ internal static class ServerStartup
             .Build();
 
         app.Use(AddVersionHeaderAsync);
+        app.UseMiddleware<ServerHeaderMiddleware>();
 
         app.MapEndpoints();
 
@@ -102,6 +105,7 @@ internal static class ServerStartup
             .AddRunOnStartupServices()
             .AddStorage()
             .AddGitHub()
+            .AddResources()
             .ConfigureHttpJsonOptions(options =>
                 options.SerializerOptions.TypeInfoResolverChain.Insert(index: 0, item: AppJsonContexts.Default)
             );

--- a/src/Credfeto.Dispatcher.Shared.Tests/Credfeto.Dispatcher.Shared.Tests.csproj
+++ b/src/Credfeto.Dispatcher.Shared.Tests/Credfeto.Dispatcher.Shared.Tests.csproj
@@ -43,6 +43,9 @@
     <!-- error NU1903: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability -->
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-xhfc-gr8f-ffwc" />
   </ItemGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
   <Import
     Project="$(SolutionDir)UnitTests.props"
     Condition="Exists('$(SolutionDir)UnitTests.props')"

--- a/src/Credfeto.Dispatcher.Shared.Tests/Middleware/ServerHeaderMiddlewareTests.cs
+++ b/src/Credfeto.Dispatcher.Shared.Tests/Middleware/ServerHeaderMiddlewareTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Threading.Tasks;
+using Credfeto.Dispatcher.Shared.Middleware;
+using FunFair.Test.Common;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Credfeto.Dispatcher.Shared.Tests.Middleware;
+
+public sealed class ServerHeaderMiddlewareTests : TestBase
+{
+    [Fact]
+    public async Task XServerHeaderShouldBeSetToMachineNameAsync()
+    {
+        DefaultHttpContext context = new();
+        ServerHeaderMiddleware middleware = new();
+
+        await middleware.InvokeAsync(context, static _ => Task.CompletedTask);
+
+        Assert.Equal(expected: Environment.MachineName, actual: (string?)context.Response.Headers["X-Server"]);
+    }
+
+    [Fact]
+    public async Task NextMiddlewareShouldBeCalledAsync()
+    {
+        DefaultHttpContext context = new();
+        bool nextCalled = false;
+        ServerHeaderMiddleware middleware = new();
+
+        await middleware.InvokeAsync(
+            context,
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            }
+        );
+
+        Assert.True(nextCalled, "next should be called");
+    }
+}

--- a/src/Credfeto.Dispatcher.Shared.Tests/SharedSetupTests.cs
+++ b/src/Credfeto.Dispatcher.Shared.Tests/SharedSetupTests.cs
@@ -1,13 +1,23 @@
+using Credfeto.Dispatcher.Shared.Middleware;
 using FunFair.Test.Common;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Credfeto.Dispatcher.Shared.Tests;
 
-public sealed class SharedSetupTests : TestBase
+public sealed class SharedSetupTests : DependencyInjectionTestsBase
 {
-    [Fact]
-    public void PlaceholderTest()
+    public SharedSetupTests(ITestOutputHelper output)
+        : base(output: output, dependencyInjectionRegistration: Configure) { }
+
+    private static IServiceCollection Configure(IServiceCollection services)
     {
-        // Placeholder test - real tests to be added
+        return services.AddResources();
+    }
+
+    [Fact]
+    public void ServerHeaderMiddlewareShouldBeRegistered()
+    {
+        this.RequireService<ServerHeaderMiddleware>();
     }
 }

--- a/src/Credfeto.Dispatcher.Shared/Credfeto.Dispatcher.Shared.csproj
+++ b/src/Credfeto.Dispatcher.Shared/Credfeto.Dispatcher.Shared.csproj
@@ -43,10 +43,7 @@
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-xhfc-gr8f-ffwc" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference
-      Include="Microsoft.Extensions.DependencyInjection.Abstractions"
-      Version="10.0.7"
-    />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference

--- a/src/Credfeto.Dispatcher.Shared/Middleware/ServerHeaderMiddleware.cs
+++ b/src/Credfeto.Dispatcher.Shared/Middleware/ServerHeaderMiddleware.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Credfeto.Dispatcher.Shared.Middleware;
+
+public sealed class ServerHeaderMiddleware : IMiddleware
+{
+    private static readonly string MachineName = Environment.MachineName;
+
+    public Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        context.Response.Headers["X-Server"] = MachineName;
+
+        return next(context);
+    }
+}

--- a/src/Credfeto.Dispatcher.Shared/SharedSetup.cs
+++ b/src/Credfeto.Dispatcher.Shared/SharedSetup.cs
@@ -1,3 +1,4 @@
+using Credfeto.Dispatcher.Shared.Middleware;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Credfeto.Dispatcher.Shared;
@@ -6,6 +7,6 @@ public static class SharedSetup
 {
     public static IServiceCollection AddResources(this IServiceCollection services)
     {
-        return services;
+        return services.AddSingleton<ServerHeaderMiddleware>();
     }
 }


### PR DESCRIPTION
## Summary

- Add `ServerHeaderMiddleware` to `Credfeto.Dispatcher.Shared` that appends `X-Server: <hostname>` to every HTTP response
- Register middleware in `ServerStartup` so it applies to all requests
- Add unit tests in `Credfeto.Dispatcher.Shared.Tests`

Closes #101

## Test plan

- [ ] `dotnet build` passes with no warnings
- [ ] All unit tests pass
- [ ] `X-Server` header present in all responses (value is `Environment.MachineName`)